### PR TITLE
Per shell keyboard shortcuts

### DIFF
--- a/FluentTerminal.App.Services/IKeyboardCommandService.cs
+++ b/FluentTerminal.App.Services/IKeyboardCommandService.cs
@@ -6,7 +6,7 @@ namespace FluentTerminal.App.Services
     public interface IKeyboardCommandService
     {
         void RegisterCommandHandler(Command command, Action handler);
-        void DeegisterCommandHandler(Command command);
+        void DeregisterCommandHandler(Command command);
         void SendCommand(Command command);
     }
 }

--- a/FluentTerminal.App.Services/IKeyboardCommandService.cs
+++ b/FluentTerminal.App.Services/IKeyboardCommandService.cs
@@ -6,6 +6,7 @@ namespace FluentTerminal.App.Services
     public interface IKeyboardCommandService
     {
         void RegisterCommandHandler(Command command, Action handler);
+        void DeegisterCommandHandler(Command command);
         void SendCommand(Command command);
     }
 }

--- a/FluentTerminal.App.Services/ISettingsService.cs
+++ b/FluentTerminal.App.Services/ISettingsService.cs
@@ -17,7 +17,7 @@ namespace FluentTerminal.App.Services
         void SaveDefaultShellProfileId(Guid id);
 
         IEnumerable<ShellProfile> GetShellProfiles();
-        void SaveShellProfile(ShellProfile shellProfile);
+        void SaveShellProfile(ShellProfile shellProfile, bool updateKeyBindings = false);
         void DeleteShellProfile(Guid id);
 
         TerminalOptions GetTerminalOptions();

--- a/FluentTerminal.App.Services/ISettingsService.cs
+++ b/FluentTerminal.App.Services/ISettingsService.cs
@@ -10,7 +10,7 @@ namespace FluentTerminal.App.Services
         event EventHandler<Guid> CurrentThemeChanged;
         event EventHandler<TerminalOptions> TerminalOptionsChanged;
         event EventHandler<ApplicationSettings> ApplicationSettingsChanged;
-        event EventHandler KeyBindingsChanged;
+        event EventHandler<Command?> KeyBindingsChanged;
 
         Guid GetDefaultShellProfileId();
         ShellProfile GetDefaultShellProfile();

--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -210,7 +210,7 @@ namespace FluentTerminal.App.Services.Implementation
 
         public Guid GetDefaultShellProfileId()
         {
-            return Guid.Parse("813f2298-210a-481a-bdbf-c17bc637a3e2");
+            return Guid.Parse("813f2298-210a-481a-bdbf-c17bc637a3e0");
         }
 
         public TerminalOptions GetDefaultTerminalOptions()
@@ -230,7 +230,7 @@ namespace FluentTerminal.App.Services.Implementation
 
         public Guid GetDefaultThemeId()
         {
-            return Guid.Parse("281e4352-bb50-47b7-a691-2b13830df95e");
+            return Guid.Parse("281e4352-bb50-47b7-a691-2b13830df950");
         }
 
         public IEnumerable<ShellProfile> GetPreinstalledShellProfiles()
@@ -244,25 +244,52 @@ namespace FluentTerminal.App.Services.Implementation
                     Arguments = string.Empty,
                     Location = @"C:\windows\system32\WindowsPowerShell\v1.0\powershell.exe",
                     PreInstalled = true,
-                    WorkingDirectory = string.Empty
+                    WorkingDirectory = string.Empty,
+                    KeyBindingCommand = Command.ShellProfileShortcut + 0,
+                    KeyBinding = new List<KeyBinding> {new KeyBinding()
+                    {
+                        Command = Command.ShellProfileShortcut + 0,
+                        Ctrl = true,
+                        Alt = true,
+                        Shift = false,
+                        Key = (int)VirtualKey.Number0
+                    } }
                 },
                 new ShellProfile
                 {
-                    Id = Guid.Parse("ab942a61-7673-4755-9bd8-765aff91d9a3"),
+                    Id = Guid.Parse("813f2298-210a-481a-bdbf-c17bc637a3e1"),
                     Name = "CMD",
                     Arguments = string.Empty,
                     Location = @"C:\Windows\System32\cmd.exe",
                     PreInstalled = true,
-                    WorkingDirectory = string.Empty
+                    WorkingDirectory = string.Empty,
+                    KeyBindingCommand = Command.ShellProfileShortcut + 1,
+                    KeyBinding = new List<KeyBinding> {new KeyBinding()
+                    {
+                        Command = Command.ShellProfileShortcut + 1,
+                        Ctrl = true,
+                        Alt = true,
+                        Shift = false,
+                        Key = (int)VirtualKey.Number1
+                    } }
                 },
                 new ShellProfile
                 {
-                    Id= Guid.Parse("e5785ad6-584f-40cb-bdcd-d5b3b3953e7f"),
+                    Id= Guid.Parse("813f2298-210a-481a-bdbf-c17bc637a3e2"),
                     Name = "WSL",
                     Arguments = string.Empty,
                     Location = @"C:\windows\system32\wsl.exe",
                     PreInstalled = true,
-                    WorkingDirectory = string.Empty
+                    WorkingDirectory = string.Empty,
+                    KeyBindingCommand = Command.ShellProfileShortcut + 2,
+                    KeyBinding = new List<KeyBinding> {new KeyBinding()
+                    {
+                        Command = Command.ShellProfileShortcut + 2,
+                        Ctrl = true,
+                        Alt = true,
+                        Shift = false,
+                        Key = (int)VirtualKey.Number2
+                    } }
                 }
             };
         }

--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -252,7 +252,7 @@ namespace FluentTerminal.App.Services.Implementation
                         Ctrl = true,
                         Alt = true,
                         Shift = false,
-                        Key = (int)VirtualKey.Number0
+                        Key = (int)ExtendedVirtualKey.Number0
                     } }
                 },
                 new ShellProfile
@@ -270,7 +270,7 @@ namespace FluentTerminal.App.Services.Implementation
                         Ctrl = true,
                         Alt = true,
                         Shift = false,
-                        Key = (int)VirtualKey.Number1
+                        Key = (int)ExtendedVirtualKey.Number1
                     } }
                 },
                 new ShellProfile
@@ -288,7 +288,7 @@ namespace FluentTerminal.App.Services.Implementation
                         Ctrl = true,
                         Alt = true,
                         Shift = false,
-                        Key = (int)VirtualKey.Number2
+                        Key = (int)ExtendedVirtualKey.Number2
                     } }
                 }
             };

--- a/FluentTerminal.App.Services/Implementation/KeyboardCommandService.cs
+++ b/FluentTerminal.App.Services/Implementation/KeyboardCommandService.cs
@@ -18,7 +18,7 @@ namespace FluentTerminal.App.Services.Implementation
             _commandHandlers[command] = handler ?? throw new ArgumentNullException(nameof(handler));
         }
 
-        public void DeegisterCommandHandler(Command command)
+        public void DeregisterCommandHandler(Command command)
         {
             if (_commandHandlers.ContainsKey(command))
             {

--- a/FluentTerminal.App.Services/Implementation/KeyboardCommandService.cs
+++ b/FluentTerminal.App.Services/Implementation/KeyboardCommandService.cs
@@ -18,6 +18,18 @@ namespace FluentTerminal.App.Services.Implementation
             _commandHandlers[command] = handler ?? throw new ArgumentNullException(nameof(handler));
         }
 
+        public void DeegisterCommandHandler(Command command)
+        {
+            if (_commandHandlers.ContainsKey(command))
+            {
+                _commandHandlers.Remove(command);
+            }
+            else
+            {
+                throw new InvalidOperationException("command not registered");
+            }
+        }
+
         public void SendCommand(Command command)
         {
             if (_commandHandlers.TryGetValue(command, out Action handler))

--- a/FluentTerminal.App.Services/Implementation/SettingsService.cs
+++ b/FluentTerminal.App.Services/Implementation/SettingsService.cs
@@ -23,7 +23,7 @@ namespace FluentTerminal.App.Services.Implementation
         public event EventHandler<Guid> CurrentThemeChanged;
         public event EventHandler<TerminalOptions> TerminalOptionsChanged;
         public event EventHandler<ApplicationSettings> ApplicationSettingsChanged;
-        public event EventHandler KeyBindingsChanged;
+        public event EventHandler<Command?> KeyBindingsChanged;
 
         public SettingsService(IDefaultValueProvider defaultValueProvider, ApplicationDataContainers containers)
         {
@@ -147,7 +147,7 @@ namespace FluentTerminal.App.Services.Implementation
         {
             _keyBindings.WriteValueAsJson(command.ToString(), keyBindings);
             _roamingSettings.WriteValueAsJson(nameof(KeyBindings), keyBindings);
-            KeyBindingsChanged?.Invoke(this, System.EventArgs.Empty);
+            KeyBindingsChanged?.Invoke(this, command);
         }
 
         public void ResetKeyBindings()
@@ -164,7 +164,7 @@ namespace FluentTerminal.App.Services.Implementation
                 _keyBindings.WriteValueAsJson(command.ToString(), _defaultValueProvider.GetDefaultKeyBindings(command));
             }
 
-            KeyBindingsChanged?.Invoke(this, System.EventArgs.Empty);
+            KeyBindingsChanged?.Invoke(this, null);
         }
 
         public Guid GetDefaultShellProfileId()
@@ -198,13 +198,16 @@ namespace FluentTerminal.App.Services.Implementation
 
             if (updateKeyBindings)
             {
-                KeyBindingsChanged?.Invoke(this, EventArgs.Empty);
+                KeyBindingsChanged?.Invoke(this, shellProfile.KeyBindingCommand);
             }
         }
 
         public void DeleteShellProfile(Guid id)
         {
-            _shellProfiles.Delete(id.ToString());
+            ShellProfile shellProfile = _shellProfiles.ReadValueFromJson<ShellProfile>(id.ToString(), null);
+            _shellProfiles.Values.Remove(id.ToString());
+            KeyBindingsChanged?.Invoke(this, shellProfile?.KeyBindingCommand);
+            //_shellProfiles.Delete(id.ToString());
         }
     }
 }

--- a/FluentTerminal.App.Services/Implementation/SettingsService.cs
+++ b/FluentTerminal.App.Services/Implementation/SettingsService.cs
@@ -205,9 +205,8 @@ namespace FluentTerminal.App.Services.Implementation
         public void DeleteShellProfile(Guid id)
         {
             ShellProfile shellProfile = _shellProfiles.ReadValueFromJson<ShellProfile>(id.ToString(), null);
-            _shellProfiles.Values.Remove(id.ToString());
+            _shellProfiles.Delete(id.ToString());
             KeyBindingsChanged?.Invoke(this, shellProfile?.KeyBindingCommand);
-            //_shellProfiles.Delete(id.ToString());
         }
     }
 }

--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -90,7 +90,7 @@ namespace FluentTerminal.App.ViewModels
 
                 try
                 {
-                    _keyboardCommandService.DeegisterCommandHandler(cmd);
+                    _keyboardCommandService.DeregisterCommandHandler(cmd);
                 }
                 catch { }
 
@@ -100,6 +100,7 @@ namespace FluentTerminal.App.ViewModels
                     if (shellProfile.KeyBindingCommand == cmd)
                     {
                         _keyboardCommandService.RegisterCommandHandler(shellProfile.KeyBindingCommand, () => AddTerminal(null, shellProfile));
+                        break;
                     }
                 }
             }

--- a/FluentTerminal.App.ViewModels/Settings/KeyBindingsViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/KeyBindingsViewModel.cs
@@ -15,13 +15,22 @@ namespace FluentTerminal.App.ViewModels.Settings
         private readonly IDialogService _dialogService;
         private readonly ICollection<KeyBinding> _keyBindings;
 
-        public KeyBindingsViewModel(Command command, ICollection<KeyBinding> keyBindings, IDialogService dialogService)
+        public KeyBindingsViewModel(Command command, ICollection<KeyBinding> keyBindings, IDialogService dialogService, string _commandName = null)
         {
             Command = command;
             _keyBindings = keyBindings;
             _dialogService = dialogService;
 
-            CommandName = EnumHelper.GetEnumDescription(command);
+            // For the shell profile bindings, the command won't have a decorator, so this is
+            // to allow us to pass in the shell name as the key binding text.
+            if (_commandName == null)
+            {
+                CommandName = EnumHelper.GetEnumDescription(command);
+            }
+            else
+            {
+                CommandName = _commandName;
+            }
 
             foreach (var binding in keyBindings)
             {

--- a/FluentTerminal.App.ViewModels/Settings/ProfilesPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/ProfilesPageViewModel.cs
@@ -19,7 +19,7 @@ namespace FluentTerminal.App.ViewModels.Settings
         private ShellProfileViewModel _selectedShellProfile;
         private SettingsViewModel _settingsParent;
 
-        public ProfilesPageViewModel(ISettingsService settingsService, IDialogService dialogService, IDefaultValueProvider defaultValueProvider, IFileSystemService fileSystemService, SettingsViewModel settingsParent = null)
+        public ProfilesPageViewModel(ISettingsService settingsService, IDialogService dialogService, IDefaultValueProvider defaultValueProvider, IFileSystemService fileSystemService, SettingsViewModel settingsParent)
         {
             _settingsParent = settingsParent;
             _settingsService = settingsService;
@@ -75,6 +75,7 @@ namespace FluentTerminal.App.ViewModels.Settings
                     _settingsService.SaveDefaultShellProfileId(ShellProfiles.First().Id);
                 }
                 _settingsService.DeleteShellProfile(shellProfile.Id);
+                _settingsParent.KeyBindings.UpdateKeyBindings();
             }
         }
 

--- a/FluentTerminal.App.ViewModels/SettingsViewModel.cs
+++ b/FluentTerminal.App.ViewModels/SettingsViewModel.cs
@@ -12,7 +12,7 @@ namespace FluentTerminal.App.ViewModels
         {
             KeyBindings = new KeyBindingsPageViewModel(settingsService, dialogService, defaultValueProvider, trayProcessCommunicationService);
             General = new GeneralPageViewModel(settingsService, dialogService, defaultValueProvider);
-            Shell = new ProfilesPageViewModel(settingsService, dialogService, defaultValueProvider, fileSystemService);
+            Shell = new ProfilesPageViewModel(settingsService, dialogService, defaultValueProvider, fileSystemService, this);
             Terminal = new TerminalPageViewModel(settingsService, dialogService, defaultValueProvider, systemFontService);
             Themes = new ThemesPageViewModel(settingsService, dialogService, defaultValueProvider, themeParserFactory, fileSystemService);
         }

--- a/FluentTerminal.App.ViewModels/ShellProfileViewModel.cs
+++ b/FluentTerminal.App.ViewModels/ShellProfileViewModel.cs
@@ -148,7 +148,7 @@ namespace FluentTerminal.App.ViewModels
 
         private async Task Delete()
         {
-            var result = await _dialogService.ShowMessageDialogAsnyc("Please confirm", "Are you sure you want to delete this theme?", DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
+            var result = await _dialogService.ShowMessageDialogAsnyc("Please confirm", "Are you sure you want to delete this profile?", DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
 
             if (result == DialogButton.OK)
             {

--- a/FluentTerminal.App.ViewModels/ShellProfileViewModel.cs
+++ b/FluentTerminal.App.ViewModels/ShellProfileViewModel.cs
@@ -22,10 +22,12 @@ namespace FluentTerminal.App.ViewModels
         private bool _inEditMode;
         private readonly ISettingsService _settingsService;
         private readonly IDialogService _dialogService;
+        private SettingsViewModel _settingsParent;
         private readonly IFileSystemService _fileSystemService;
 
-        public ShellProfileViewModel(ShellProfile shellProfile, ISettingsService settingsService, IDialogService dialogService, IFileSystemService fileSystemService)
+        public ShellProfileViewModel(ShellProfile shellProfile, ISettingsService settingsService, IDialogService dialogService, IFileSystemService fileSystemService, SettingsViewModel settingsParent)
         {
+            _settingsParent = settingsParent;
             _shellProfile = shellProfile;
             _settingsService = settingsService;
             _dialogService = dialogService;
@@ -105,6 +107,9 @@ namespace FluentTerminal.App.ViewModels
             _settingsService.SaveShellProfile(_shellProfile);
 
             InEditMode = false;
+
+            // Now update the KeyBindings page becuse this shell's stuff has changed.
+            _settingsParent.KeyBindings.UpdateKeyBindings();
         }
 
         private async Task CancelEdit()

--- a/FluentTerminal.App.ViewModels/TerminalViewModel.cs
+++ b/FluentTerminal.App.ViewModels/TerminalViewModel.cs
@@ -62,8 +62,9 @@ namespace FluentTerminal.App.ViewModels
             
         }
 
-        private async void OnKeyBindingsChanged(object sender, EventArgs e)
+        private async void OnKeyBindingsChanged(object sender, Command? e)
         {
+            // First, update the keybindings in the JavaScript terminal view
             var keyBindings = _settingsService.GetKeyBindings();
             await _applicationView.RunOnDispatcherThread(async () =>
             {

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -114,7 +114,7 @@ namespace FluentTerminal.App
                     {
                         if (_applicationSettings.NewTerminalLocation == NewTerminalLocation.Tab && _mainViewModels.Count > 0)
                         {
-                            await _mainViewModels.Last().AddTerminal(parameter, false).ConfigureAwait(true);
+                            await _mainViewModels.Last().AddTerminal(parameter, _settingsService.GetDefaultShellProfile()).ConfigureAwait(true);
                         }
                         else
                         {
@@ -132,7 +132,7 @@ namespace FluentTerminal.App
                     else if (command == "new")
                     {
                         var viewModel = _container.Resolve<MainViewModel>();
-                        await viewModel.AddTerminal(parameter, false).ConfigureAwait(true);
+                        await viewModel.AddTerminal(parameter, _settingsService.GetDefaultShellProfile()).ConfigureAwait(true);
                         await CreateMainView(typeof(MainPage), viewModel, true).ConfigureAwait(true);
                     }
                 }
@@ -144,7 +144,7 @@ namespace FluentTerminal.App
             if (!_alreadyLaunched)
             {
                 var viewModel = _container.Resolve<MainViewModel>();
-                await viewModel.AddTerminal(null, false).ConfigureAwait(true);
+                await viewModel.AddTerminal(null, _settingsService.GetDefaultShellProfile()).ConfigureAwait(true);
                 await CreateMainView(typeof(MainPage), viewModel, true).ConfigureAwait(true);
                 Window.Current.Activate();
             }
@@ -239,7 +239,7 @@ namespace FluentTerminal.App
                 mainViewModel.NewWindowRequested += OnNewWindowRequested;
                 mainViewModel.ShowSettingsRequested += OnShowSettingsRequested;
                 _mainViewModels.Add(mainViewModel);
-                await mainViewModel.AddTerminal(directory, false).ConfigureAwait(true);
+                await mainViewModel.AddTerminal(directory, _settingsService.GetDefaultShellProfile()).ConfigureAwait(true);
             }
 
             if (viewModel is SettingsViewModel settingsViewModel)

--- a/FluentTerminal.App/Views/SettingsPages/KeyBindingSettings.xaml.cs
+++ b/FluentTerminal.App/Views/SettingsPages/KeyBindingSettings.xaml.cs
@@ -22,14 +22,29 @@ namespace FluentTerminal.App.Views.SettingsPages
             {
                 ViewModel = viewModel;
 
-                foreach (var value in Enum.GetValues(typeof(Command)))
+                foreach (Command command in Enum.GetValues(typeof(Command)))
                 {
-                    var command = (Command)value;
+                    // Don't enumerate explicit keybinding enums that are in the range of a profile shortcut
+                    // since they won't be directly assigned to in the KeyBindings settings panels.
+                    if (command < Command.ShellProfileShortcut)
+                    {
+                        AddCommandMenu.Items.Add(new MenuFlyoutItem
+                        {
+                            Text = EnumHelper.GetEnumDescription(command),
+                            Command = ViewModel.AddCommand,
+                            CommandParameter = command
+                        });
+                    }
+                }
+
+                // Add all of the shells we know of.
+                foreach (var shellProfile in viewModel.ShellProfiles)
+                {
                     AddCommandMenu.Items.Add(new MenuFlyoutItem
                     {
-                        Text = EnumHelper.GetEnumDescription(command),
+                        Text = shellProfile.Name + " Shortcut",
                         Command = ViewModel.AddCommand,
-                        CommandParameter = command
+                        CommandParameter = shellProfile.KeyBindingCommand
                     });
                 }
             }

--- a/FluentTerminal.Models/Enums/Command.cs
+++ b/FluentTerminal.Models/Enums/Command.cs
@@ -4,46 +4,52 @@ namespace FluentTerminal.Models.Enums
 {
     public enum Command
     {
+        // Explicitly assign the values of the enums, to ensure that we don't end up with them in weird places
+        // in the integer spectrum. This allows us to reserver 1024 and up for shell profile shortcuts safely.
+
         [Description("Toggle window")]
-        ToggleWindow,
+        ToggleWindow = 0,
 
         [Description("Next tab")]
-        NextTab,
+        NextTab = 1,
 
         [Description("Previous tab")]
-        PreviousTab,
+        PreviousTab = 2,
 
         [Description("New tab")]
-        NewTab,
+        NewTab = 3,
 
         [Description("Configurable new tab")]
-        ConfigurableNewTab,
+        ConfigurableNewTab = 4,
 
         [Description("Close tab")]
-        CloseTab,
+        CloseTab = 5,
 
         [Description("New window")]
-        NewWindow,
+        NewWindow = 6,
 
         [Description("Show settings")]
-        ShowSettings,
+        ShowSettings = 7,
 
         [Description("Copy")]
-        Copy,
+        Copy = 8,
 
         [Description("Paste")]
-        Paste,
+        Paste = 9,
 
         [Description("Search")]
-        Search,
+        Search = 10,
 
         [Description("Toggle Fullscreen")]
-        ToggleFullScreen,
+        ToggleFullScreen = 11,
 
         [Description("Select all")]
-        SelectAll,
+        SelectAll = 12,
 
         [Description("Clear")]
-        Clear
+        Clear = 13,
+
+        [Description("ShellProfileShortcuts")]
+        ShellProfileShortcut = 1024
     }
 }

--- a/FluentTerminal.Models/ShellProfile.cs
+++ b/FluentTerminal.Models/ShellProfile.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using FluentTerminal.Models.Enums;
 
 namespace FluentTerminal.Models
 {
@@ -10,5 +12,7 @@ namespace FluentTerminal.Models
         public string Arguments { get; set; }
         public string Location { get; set; }
         public string WorkingDirectory { get; set; }
+        public Command KeyBindingCommand { get; set; }
+        public ICollection<KeyBinding> KeyBinding { get; set; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,35 +1,40 @@
+# Fluent Terminal
+
+A Terminal Emulator based on UWP and web technologies.
 
 [![Build status](https://ci.appveyor.com/api/projects/status/4r429bv594fxkygd?svg=true)](https://ci.appveyor.com/project/felixse/fluentterminal)
 
-# Fluent Terminal
-A Terminal Emulator based on UWP and web technologies.
+## Features
 
-## Features:
 - Terminal for PowerShell, CMD, (default) WSL or arbitrary custom shells
   - Support for shell arguments allows for native support of remote shells through SSH or other remote-access CLI tools.
 - Supports tabs and multiple windows
-- Theming and appearance configuration
+- Themes and appearance configuration
 - Editable keybindings
 - Search function
 - Configure shell profiles to quickly switch between different shells
 - Explorer context menu integration (Installation script can be found [here](https://github.com/felixse/FluentTerminal/tree/master/Explorer%20Context%20Menu%20Integration))
 
-## Screenshots:
+## Screenshots
+
 ![Terminal window](Screenshots/Terminal.png)
 ![Settings window](Screenshots/Settings.png)
 
-## Up Next:
+## Up Next
+
 - Split screen support
 - Full screen mode
 - Import/Export themes
 
 ## How to install
+
 - activate the developer mode as described [here](https://docs.microsoft.com/en-US/windows/uwp/get-started/enable-your-device-for-development)
 - Install the *.cer file into `Local Machine` -> `Trusted Root Certification Authorities`
 - double click the *.appxbundle
 - Optional: Install Context menu integration from [here](https://github.com/felixse/FluentTerminal/tree/master/Explorer%20Context%20Menu%20Integration))
 
-## How to build:
+## How to build
+
 Build the Client first, or whenever edited by running `npm run build` in FluentTerminal.Client  
 Everything else is part of the solution.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 A Terminal Emulator based on UWP and web technologies.
 
 ## Features:
-- Terminal for PowerShell, CMD, WSL, or custom shells
+- Terminal for PowerShell, CMD, (default) WSL or arbitrary custom shells
+  - Support for shell arguments allows for native support of remote shells through SSH or other remote-access CLI tools.
 - Supports tabs and multiple windows
 - Theming and appearance configuration
 - Editable keybindings
@@ -31,3 +32,31 @@ A Terminal Emulator based on UWP and web technologies.
 ## How to build:
 Build the Client first, or whenever edited by running `npm run build` in FluentTerminal.Client  
 Everything else is part of the solution.
+
+- Grab the [latest NodeJS 8.x installer](https://nodejs.org/en/download/), and install ensuring that both NPM and "install into system PATH" are checked during the install process.
+- Grab the [latest Visual Studio 2017 Community installer](https://www.visualstudio.com/downloads/) and install (See next section)
+- [Enable developer mode in Windows 10](https://docs.microsoft.com/en-US/windows/uwp/get-started/enable-your-device-for-development)
+
+### Visual Studio 2017 Configuration
+
+- Under "Workloads" select:
+  - Universal Windows Platform development
+  - Node.js development (Probably not required, given we installed Node.js separately)
+- Under individual components, you'll need to install the following:
+  - Git for Windows
+  - .NET Core runtime
+  - .NET 4.7.1 Targeting Pack
+  - Windows SDK 16299 for UWP: C#, VB, JS
+
+### The First Build
+
+- Before opening the solution, go into the `FluentTerminal.Client` folder and run:
+  - `npm install` (Ignore the warnings related to `fluent-terminal-client`)
+  - `npm run build`
+- When the solution is first opened, it will help to set the architecture to x64 for testing, as we didn't install the ARM cross-compiling stuff for VS2017.
+- When first built, Visual studio will spend a significant amount of time resolving dependencies, and fetching additional components vai nuGet. This is normal.
+  - If you have done the steps so far correctly, and the build is left as a debug build, then the solution should build successfully should launch correctly when you press F5.
+
+### Subsequent Builds
+
+- If you change the `FluentTerminal.Client` contents, you'll need to re-run the `npm run build` (and `npm install` if you change the dependencies).


### PR DESCRIPTION
There are several architectural discussions to have on this PR:

There are a couple breaking changes:

- This futzes with the GUIDs associated with the default shells
- Existing installs won't have the key bindings for the default shells, and I don't know how it'll respond to installs where there are custom shells without any key bindings.
- The command enum values have been explicitly set, so if they weren't set to their now explicit values, that'll cause issues in previous installs where it may just straight up crash on start.

Discussion points:

- Key bindings for shells are tied to the shell profile (for storage), and are saved with the shell profiles, not with the key bindings.
  - Key bindings for shells are still edited in the Key Bindings settings panel, and not with the shell profile itself. This was done mostly because I don't know XAML that well, and didn't want to futz around with that, but also because key bindings edit workflows don't follow the Edit/Save workflow of the shell profiles themselves (where they are read-only fields until you Edit the profile, etc...). This felt more natural from a UI/UX perspective, but did require some fudging to pass the ability to for the shell profile model to be able to trigger a key binding refresh on the key bindings panel when shells were added or deleted.
- This attempts to maintain the current flow of keyboard shortcut handling:
  - Register keyboard command handlers that call AddTerminal(), which had its signature changed to accept a shell profile to launch with. The registering of handlers that are available on startup is easy and handled in the MainViewModel initialization, and subsequent shell profiles are handled by having the MainViewModel add another KeyBindingChange event callback, which has access to the shells.
- Shells now have a KeyBinding property which is the list f bindings, as well as a KeyBindingCommand which is the Enum value of the command, basically taken as something in the 1024 and up range, or more specifically as something >= Command.ShellProfileShortcut.
  - There's an opportunity here to convert this KeyBindingCommand and the Id into some unified thing, but since the Command enum is used in a lot of places, conflating those two isn't something we can do without a major architectural decision, and as a PR contribution this didn't seem like the time for that.
- There's a conversation to be had about whether or not using the existing Command/KeyBinding/KeyboardCommandHandler paradigm is the right call for shell profiles, given that those shortcuts are always going to be caught by the TerminalView, and the action could just be taken there. That might simplify the code, but it would need some justification for why we're handling keyboard commands in a variety of different ways (and would make maintaining other keyboard shortcuts a little trickier, or at least more ambiguous).

Notes:

- There's a lot of linear searching through the shells list, which should be fixed by sorting out the discrepancy 