### PR TITLE
Update readme to address issues with loopback exemption

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A Terminal Emulator based on UWP and web technologies.
   - Alternatively, [enable developer mode](https://docs.microsoft.com/en-US/windows/uwp/get-started/enable-your-device-for-development) if you plan to do UWP app development. **For most users that do not intend to do UWP app development, developer mode will not be necessary.**
 - Install the *.cer file into `Local Machine` -> `Trusted Root Certification Authorities`
 - double click the *.appxbundle
-- If you did not enable developer mode, you'll have to run the following Powershell snippet in an Administrative/elevated Powershell prompt (addresses issues such as the one described in #43)
+- If you did not enable developer mode, you'll have to run the following Powershell snippet in an Administrative/elevated Powershell prompt (addresses issues such as the one described in [#43](https://github.com/felixse/FluentTerminal/issues/43))
   ```powershell
   $packageFamily = (Get-AppxPackage | where { $_.Name -eq "53621FSApps.FluentTerminal" }).PackageFamilyName
   CheckNetIsolation.exe LoopbackExempt -a -n="$packageFamily"

--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ A Terminal Emulator based on UWP and web technologies.
 ## How to install
 - [Enable sideloading apps ](https://www.windowscentral.com/how-enable-windows-10-sideload-apps-outside-store
 )
-  - Alternatively, enable developer mode
+  - Alternatively, [enable developer mode](https://docs.microsoft.com/en-US/windows/uwp/get-started/enable-your-device-for-development) if you plan to do UWP app development. **For most users that do not intend to do UWP app development, developer mode will not be necessary.**
 - Install the *.cer file into `Local Machine` -> `Trusted Root Certification Authorities`
 - double click the *.appxbundle
-- Run the following Powershell snippet in an Administrative/elevated Powershell prompt (addresses issues such as the one described in #43)
+- If you did not enable developer mode, you'll have to run the following Powershell snippet in an Administrative/elevated Powershell prompt (addresses issues such as the one described in #43)
   ```powershell
   $packageFamily = (Get-AppxPackage | where { $_.Name -eq "53621FSApps.FluentTerminal" }).PackageFamilyName
   CheckNetIsolation.exe LoopbackExempt -a -n="$packageFamily"
   ```
-- Optional: Install Context menu integration from [here](https://github.com/felixse/FluentTerminal/tree/master/Explorer%20Context%20Menu%20Integration))
+- **Optional:** Install Context menu integration from [here](https://github.com/felixse/FluentTerminal/tree/master/Explorer%20Context%20Menu%20Integration))
 
 ## How to build:
 Build the Client first, or whenever edited by running `npm run build` in FluentTerminal.Client  

--- a/README.md
+++ b/README.md
@@ -24,9 +24,16 @@ A Terminal Emulator based on UWP and web technologies.
 - Import/Export themes
 
 ## How to install
-- activate the developer mode as described [here](https://docs.microsoft.com/en-US/windows/uwp/get-started/enable-your-device-for-development)
+- [Enable sideloading apps ](https://www.windowscentral.com/how-enable-windows-10-sideload-apps-outside-store
+)
+  - Alternatively, enable developer mode
 - Install the *.cer file into `Local Machine` -> `Trusted Root Certification Authorities`
 - double click the *.appxbundle
+- Run the following Powershell snippet in an Administrative/elevated Powershell prompt (addresses issues such as the one described in #43)
+  ```powershell
+  $packageFamily = (Get-AppxPackage | where { $_.Name -eq "53621FSApps.FluentTerminal" }).PackageFamilyName
+  CheckNetIsolation.exe LoopbackExempt -a -n="$packageFamily"
+  ```
 - Optional: Install Context menu integration from [here](https://github.com/felixse/FluentTerminal/tree/master/Explorer%20Context%20Menu%20Integration))
 
 ## How to build:


### PR DESCRIPTION
Updated the readme to provide instructions about enabling sideloading apps, and changing the wording around developer mode to be optional for _users_, at this point. Added the extra step to manually enable the loopback exemption if you've only got sideloading apps enabled.