### PR TITLE
Return an empty string when attempting to paste non-text clipboard buffer

### DIFF
--- a/FluentTerminal.App/Services/ClipboardService.cs
+++ b/FluentTerminal.App/Services/ClipboardService.cs
@@ -13,7 +13,8 @@ namespace FluentTerminal.App.Services
             {
                 return content.GetTextAsync().AsTask();
             }
-            return null;
+            // Otherwise return a new task that just sends an empty string.
+            return new Task<string>(new Func<string>(() => ""));
         }
 
         public void SetText(string text)

--- a/FluentTerminal.App/Services/ClipboardService.cs
+++ b/FluentTerminal.App/Services/ClipboardService.cs
@@ -14,7 +14,7 @@ namespace FluentTerminal.App.Services
                 return content.GetTextAsync().AsTask();
             }
             // Otherwise return a new task that just sends an empty string.
-            return new Task<string>(new Func<string>(() => ""));
+            return Task.FromResult(string.Empty);
         }
 
         public void SetText(string text)


### PR DESCRIPTION
Returning null Task reference was causing a crash when attempting to paste a non-text buffer.