### PR TITLE
Fix display issue when settings window is too narrow

### DIFF
--- a/FluentTerminal.App/Views/SettingsPage.xaml
+++ b/FluentTerminal.App/Views/SettingsPage.xaml
@@ -18,7 +18,7 @@
             x:Name="NavigationView"
             AlwaysShowHeader="False"
             Canvas.ZIndex="0"
-            CompactModeThresholdWidth="560"
+            CompactModeThresholdWidth="0"
             ExpandedModeThresholdWidth="560"
             IsSettingsVisible="False"
             Loaded="NavigationView_Loaded"


### PR DESCRIPTION
Disable compact mode for the settings window (which removes the sidebar) entirely. Instead now the side bar is just collapsed at `560` (I guess pixels?).

### Preview

![settings-window-fix-preview](https://user-images.githubusercontent.com/3742559/48092522-8fd39980-e215-11e8-8657-11f5b550e00b.gif)
