### PR TITLE
Add "Show in system tray" option

### DIFF
--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -21,7 +21,8 @@ namespace FluentTerminal.App.Services.Implementation
                 MouseMiddleClickAction = MouseAction.None,
                 MouseRightClickAction = MouseAction.ContextMenu,
                 AlwaysShowTabs = false,
-                ShowNewOutputIndicator = false
+                ShowNewOutputIndicator = false,
+                EnableTrayIcon = true
             };
         }
 

--- a/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
@@ -53,6 +53,20 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
+        public bool EnableTrayIcon
+        {
+            get => _applicationSettings.EnableTrayIcon;
+            set
+            {
+                if (_applicationSettings.EnableTrayIcon != value)
+                {
+                    _applicationSettings.EnableTrayIcon = value;
+                    _settingsService.SaveApplicationSettings(_applicationSettings);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
         public bool ShowNewOutputIndicator
         {
             get => _applicationSettings.ShowNewOutputIndicator;
@@ -241,6 +255,7 @@ namespace FluentTerminal.App.ViewModels.Settings
                 NewTerminalLocation = defaults.NewTerminalLocation;
                 AlwaysShowTabs = defaults.AlwaysShowTabs;
                 ShowNewOutputIndicator = defaults.ShowNewOutputIndicator;
+                EnableTrayIcon = defaults.EnableTrayIcon;
             }
         }
 

--- a/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
@@ -19,6 +19,7 @@ namespace FluentTerminal.App.ViewModels.Settings
         private bool _editingTabsPosition;
         private bool _editingInactiveTabColorMode;
         private bool _startupTaskEnabled;
+        private bool _shouldRestartForTrayMessage;
         private string _startupTaskErrorMessage;
 
         public GeneralPageViewModel(ISettingsService settingsService, IDialogService dialogService, IDefaultValueProvider defaultValueProvider, IStartupTaskService startupTaskService)
@@ -63,8 +64,17 @@ namespace FluentTerminal.App.ViewModels.Settings
                     _applicationSettings.EnableTrayIcon = value;
                     _settingsService.SaveApplicationSettings(_applicationSettings);
                     RaisePropertyChanged();
+
+                    // Toggle message telling user to restart the program
+                    ShouldRestartForTrayMessage = !ShouldRestartForTrayMessage;
                 }
             }
+        }
+
+        public bool ShouldRestartForTrayMessage
+        {
+            get => _shouldRestartForTrayMessage;
+            set => Set(ref _shouldRestartForTrayMessage, value);
         }
 
         public bool ShowNewOutputIndicator

--- a/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
@@ -44,6 +44,10 @@
                     Foreground="Red"
                     Text="{x:Bind ViewModel.StartupTaskErrorMessage, Mode=OneWay}"
                     Visibility="{x:Bind ViewModel.CanEnableStartupTask, Mode=OneWay, Converter={StaticResource FalseToVisibleConverter}}" />
+                <ToggleSwitch
+                    Margin="0,24,0,0"
+                    Header="Show in system tray"
+                    IsOn="{x:Bind ViewModel.EnableTrayIcon, Mode=TwoWay}" />
                 <TextBlock Margin="0,24,0,8" Text="Open new terminals as" />
                 <RadioButton
                     Content="Tabs"

--- a/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
@@ -50,7 +50,7 @@
                     IsOn="{x:Bind ViewModel.EnableTrayIcon, Mode=TwoWay}" />
                 <TextBlock
                     Foreground="Red"
-                    Text="Requires restart to take affect"
+                    Text="Relaunch required to apply setting"
                     Visibility="{x:Bind ViewModel.ShouldRestartForTrayMessage, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}" />
                 <TextBlock Margin="0,24,0,8" Text="Open new terminals as" />
                 <RadioButton

--- a/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
@@ -48,6 +48,10 @@
                     Margin="0,24,0,0"
                     Header="Show in system tray"
                     IsOn="{x:Bind ViewModel.EnableTrayIcon, Mode=TwoWay}" />
+                <TextBlock
+                    Foreground="Red"
+                    Text="Requires restart to take affect"
+                    Visibility="{x:Bind ViewModel.ShouldRestartForTrayMessage, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}" />
                 <TextBlock Margin="0,24,0,8" Text="Open new terminals as" />
                 <RadioButton
                     Content="Tabs"

--- a/FluentTerminal.Models/ApplicationSettings.cs
+++ b/FluentTerminal.Models/ApplicationSettings.cs
@@ -15,5 +15,6 @@ namespace FluentTerminal.Models
         public MouseAction MouseRightClickAction { get; set; }
         public bool AlwaysShowTabs { get; set; }
         public bool ShowNewOutputIndicator { get; set; }
+        public bool EnableTrayIcon { get; set; }
     }
 }

--- a/FluentTerminal.SystemTray/Program.cs
+++ b/FluentTerminal.SystemTray/Program.cs
@@ -61,7 +61,15 @@ namespace FluentTerminal.SystemTray
 
                 Task.Run(() => container.Resolve<IUpdateService>().CheckForUpdate());
 
-                Application.Run(container.Resolve<SystemTrayApplicationContext>());
+                var settingsService = container.Resolve<ISettingsService>();
+                if (settingsService.GetApplicationSettings().EnableTrayIcon)
+                {
+                    Application.Run(container.Resolve<SystemTrayApplicationContext>());
+                }
+                else
+                {
+                    Application.Run();
+                }
 
                 mutex.Close();
             }


### PR DESCRIPTION
As requested in #137, added an option to the settings to enable or disable the tray icon. The current implementation requires the user to restart FluentTerminal in order for the option to take affect (and they're informed about this in the UI)

![system_tray_option_preview](https://user-images.githubusercontent.com/3742559/48973121-07406000-f041-11e8-943d-24d767270ec1.gif)


Ideally the system tray icon should just appear/disappear as the option is toggled, but I couldn't get that to work. The [`SettingsService` in Program.cs](https://github.com/felixse/FluentTerminal/blob/d9b7052e871ed28e0e48d10f85f73371b3e58787/FluentTerminal.SystemTray/Program.cs#L49) does not respond to the [`ApplicationSettingsChanged` event](https://github.com/felixse/FluentTerminal/blob/master/FluentTerminal.App.Services/Implementation/SettingsService.cs#L49) because the Settings views use the [`SettingsService` in App.xaml.cs](https://github.com/felixse/FluentTerminal/blob/d9b7052e871ed28e0e48d10f85f73371b3e58787/FluentTerminal.App/App.xaml.cs#L61), so I couldn't start/stop the tray icon from there. And in App.xaml.cs I do not have access to [`Application`](https://github.com/felixse/FluentTerminal/blob/d9b7052e871ed28e0e48d10f85f73371b3e58787/FluentTerminal.SystemTray/Program.cs#L64) in order to start/stop the tray icon, as far as I know.