### PR TITLE
fix #114 scrolling issue on presicion touchpads

### DIFF
--- a/FluentTerminal.Client/src/index.html
+++ b/FluentTerminal.Client/src/index.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" href="xterm.css" />
     <link rel="stylesheet" href="style.css" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
 </head>
 
 <body>

--- a/FluentTerminal.Client/src/index.js
+++ b/FluentTerminal.Client/src/index.js
@@ -145,14 +145,11 @@ function changeOptions(options) {
 }
 
 function setScrollBarStyle(scrollBarStyle) {
-  if (scrollBarStyle == 'hidden') {
-    document.getElementById('terminal-container').style['-ms-overflow-style'] = 'none';
-  } else if (scrollBarStyle == 'autoHiding') {
-    document.getElementById('terminal-container').style['-ms-overflow-style'] = '-ms-autohiding-scrollbar';
-  } else if (scrollBarStyle == 'visible') {
-    document.getElementById('terminal-container').style['-ms-overflow-style'] = 'scrollbar';
+  switch (scrollBarStyle) {
+  	case 'hidden':     return terminalContainer.style['-ms-overflow-style'] = 'none';
+  	case 'autoHiding': return terminalContainer.style['-ms-overflow-style'] = '-ms-autohiding-scrollbar';
+  	case 'visible':    return terminalContainer.style['-ms-overflow-style'] = 'scrollbar';
   }
-  
 }
 
 function setPadding(padding) {

--- a/FluentTerminal.Client/src/style.css
+++ b/FluentTerminal.Client/src/style.css
@@ -1,15 +1,24 @@
 * {
     margin: 0;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
 html, body {
     background: transparent;
     height: 100%;
-  }
+    width: 100%;
+    overflow: hidden;
+    -ms-content-zooming: none;
+}
 
 #terminal-container {
     width: 100%;
     height: 100%;
+    /* reenable scrolling only in the exterm */
+    overflow-y: auto;
+    overflow-x: hidden;
+    touch-action: pan-y;
+    -ms-touch-action: pan-y;
 }
 
 .xterm .xterm-viewport {

--- a/FluentTerminal.Client/src/style.css
+++ b/FluentTerminal.Client/src/style.css
@@ -1,6 +1,5 @@
 * {
     margin: 0;
-    -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
 html, body {

--- a/FluentTerminal.Client/src/style.css
+++ b/FluentTerminal.Client/src/style.css
@@ -14,7 +14,7 @@ html, body {
 #terminal-container {
     width: 100%;
     height: 100%;
-    /* reenable scrolling only in the exterm */
+    /* re-enable scrolling only in the xterm container */
     overflow-y: auto;
     overflow-x: hidden;
     touch-action: pan-y;


### PR DESCRIPTION
Hello,
first of all - amazing app, what I've been longing to find or wanting to make myself for a long time.

Since Surface Pro is my mainly driver, the precision touhpad scrolling issue #114 has been a dealbreaker for a while now so I decided to fix it. I've been making some EdgeHTML & HTML UWP apps for a while so I already came across this is pretty basic bug (*unless MS decided to market it a feature and call it a day :D*) plaguing all my projects.

**What's been happening?**
Scroll events are getting captured by `<body>` or `<html>` and since it has no scrollbar and no content larger than elements visible portion, EdgeHTML does the overflow bounce effect.

There's also adjacent issue to the scrolling which only surfaces on precision touchpads - pinch zooming. Also side scrolling.

**What's I've done**
* Applied overflow hidden on body and html making it not scrollable because there's no content to scroll
* Made the xterm's container scrollable and threw in pointer events for a good measure
* prevented zooming, both with touchpad and through touch.
* bonus: made the scrollbar autohide because it's super cool ;)

**Observations**
Unfortunately the scrolling isn't smooth as one would expect from UWP app because the scrolling of the terminal is handled by xterm, making it jump an entire line every time you scroll.

Touch scrolling is does not work, instead touch creates text selection. I did not investigate further. I suppose it's also on the xterm's side of thing. And maybe it's a desired behavior. If not, we could create separate issue and fix it later.

This may not be the complete solution, though it's a step in the right direction. I've been testing it for a while now and it works great :)
