### PR TITLE
Press enter to close an InputDialog

### DIFF
--- a/FluentTerminal.App/Dialogs/InputDialog.xaml
+++ b/FluentTerminal.App/Dialogs/InputDialog.xaml
@@ -7,6 +7,7 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
     CloseButtonText="Cancel"
     PrimaryButtonText="OK"
+    KeyDown="Dialog_KeyUp"
     mc:Ignorable="d">
     <TextBox VerticalAlignment="Center" Text="{x:Bind Input, Mode=TwoWay}" />
 </ContentDialog>

--- a/FluentTerminal.App/Dialogs/InputDialog.xaml.cs
+++ b/FluentTerminal.App/Dialogs/InputDialog.xaml.cs
@@ -2,11 +2,15 @@
 using System.Threading.Tasks;
 using Windows.UI.Xaml.Controls;
 using System;
+using Windows.UI.Xaml.Input;
+using Windows.System;
 
 namespace FluentTerminal.App.Dialogs
 {
     public sealed partial class InputDialog : ContentDialog, IInputDialog
     {
+
+        private bool EnterPressed = false;
         public string Input { get; private set; }
 
         public InputDialog()
@@ -17,7 +21,7 @@ namespace FluentTerminal.App.Dialogs
         public async Task<string> GetInput()
         {
             var result = await ShowAsync();
-            if (result == ContentDialogResult.Primary)
+            if (result == ContentDialogResult.Primary || EnterPressed)
             {
                 return Input;
             }
@@ -27,6 +31,15 @@ namespace FluentTerminal.App.Dialogs
         public void SetTitle(string title)
         {
             Title = title;
+        }
+
+        void Dialog_KeyUp(object sender, KeyRoutedEventArgs e)
+        {
+           if (e.Key == VirtualKey.Enter)
+           {
+                EnterPressed = true;
+                Hide();
+           }
         }
     }
 }


### PR DESCRIPTION
... As if the primary button is pressed.

Closes #174 (the original request)


### Implementation
I did not figure out how to have `result` be equal to `ContentDialogResult.Primary` (as seen [here](https://github.com/felixse/FluentTerminal/blob/6be29f49d7c5db18c4fa4c49261f56cb6dfa805a/FluentTerminal.App/Dialogs/InputDialog.xaml.cs#L20)) so I used an internal variable to communicate the intent of closing the dialog.