### PR TITLE
Add option to use bold text in terminals

### DIFF
--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -305,6 +305,7 @@ namespace FluentTerminal.App.Services.Implementation
                 ScrollBarStyle = ScrollBarStyle.Hidden,
                 FontFamily = "Consolas",
                 FontSize = 13,
+                BoldText = false,
                 BackgroundOpacity = 0.8,
                 Padding = 12,
                 ScrollBackLimit = 1000

--- a/FluentTerminal.App.ViewModels/Settings/TerminalPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/TerminalPageViewModel.cs
@@ -136,6 +136,20 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
+        public bool BoldText
+        {
+            get => _terminalOptions.BoldText;
+            set
+            {
+                if (_terminalOptions.BoldText != value)
+                {
+                    _terminalOptions.BoldText = value;
+                    _settingsService.SaveTerminalOptions(_terminalOptions);
+                    this.RaisePropertyChanged();
+                }
+            }
+        }
+
         public IEnumerable<string> Fonts { get; }
 
         public int FontSize

--- a/FluentTerminal.App.ViewModels/Settings/TerminalPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/TerminalPageViewModel.cs
@@ -220,6 +220,7 @@ namespace FluentTerminal.App.ViewModels.Settings
                 ScrollBarStyle = defaults.ScrollBarStyle;
                 FontFamily = defaults.FontFamily;
                 FontSize = defaults.FontSize;
+                BoldText = defaults.BoldText;
                 BackgroundOpacity = defaults.BackgroundOpacity;
                 ScrollBackLimit = defaults.ScrollBackLimit.ToString();
             }

--- a/FluentTerminal.App/Views/SettingsPages/TerminalSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/TerminalSettings.xaml
@@ -52,6 +52,10 @@
                     Header="Font size"
                     ItemsSource="{x:Bind ViewModel.Sizes}"
                     SelectedValue="{x:Bind ViewModel.FontSize, Mode=TwoWay}" />
+                <ToggleSwitch
+                    Margin="0,0,0,24"
+                    Header="Bold text"
+                    IsOn="{x:Bind ViewModel.BoldText, Mode=TwoWay}" />
                 <Slider
                     Width="200"
                     Margin="0,0,0,24"

--- a/FluentTerminal.Client/src/index.js
+++ b/FluentTerminal.Client/src/index.js
@@ -29,6 +29,8 @@ function createTerminal(options, theme, keyBindings) {
   var terminalOptions = {
     fontFamily: options.fontFamily,
     fontSize: options.fontSize,
+    fontWeight: options.boldText ? 'bold' : 'normal',
+    fontWeightBold: options.boldText ? 'bolder' : 'bold',
     cursorStyle: options.cursorStyle,
     cursorBlink: options.cursorBlink,
     bellStyle: options.bellStyle,
@@ -139,6 +141,8 @@ function changeOptions(options) {
   term.setOption('cursorStyle', options.cursorStyle);
   term.setOption('fontFamily', options.fontFamily);
   term.setOption('fontSize', options.fontSize);
+  term.setOption('fontWeight', options.boldText ? 'bold' : 'normal');
+  term.setOption('fontWeightBold', options.boldText ? 'bolder' : 'bold');
   term.setOption('scrollback', options.scrollBackLimit);
   setScrollBarStyle(options.scrollBarStyle);
   setPadding(options.padding);

--- a/FluentTerminal.Models/TerminalOptions.cs
+++ b/FluentTerminal.Models/TerminalOptions.cs
@@ -8,6 +8,8 @@ namespace FluentTerminal.Models
 
         public int FontSize { get; set; }
 
+        public bool BoldText { get; set; }
+
         public CursorStyle CursorStyle { get; set; }
 
         public bool CursorBlink { get; set; }


### PR DESCRIPTION
Closes #182

Adds a toggle to the Terminal Page to enable/disable bold text in terminals. Currently, from my testing, when `BoldText` is enabled there is no real distinction between normal and bold text in most fonts, I also addressed this in [this comment](https://github.com/felixse/FluentTerminal/issues/182#issuecomment-455901102).

### Alternative implementation
Currently the conversion from boolean to `fontWeight` and `fontWeightBold` value is performed 2x each, alternatively we could use transformer functions, e.g. ⬇️, but this seems like overkill to me.

```javascript
term.setOption('fontWeight', boldToFontWeight(options.boldText));
term.setOption('fontWeightBold', boldToFontWeightBold(options.boldText));

...

function boldToFontWeight(boldText) {
  return options.boldText ? 'bold' : 'normal';
}
function boldToFontWeightBold(boldText) {
  return options.boldText ? 'bolder' : 'bold';
}
```