### PR TITLE
Add keybinding to change the (current) tab title

### DIFF
--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -125,7 +125,7 @@ namespace FluentTerminal.App.Services.Implementation
                         Ctrl = true,
                         Alt = false,
                         Shift = true,
-                        Key = (int)ExtendedVirtualKey.N
+                        Key = (int)ExtendedVirtualKey.R
                     }
                 };
 

--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -116,6 +116,19 @@ namespace FluentTerminal.App.Services.Implementation
                     }
                 };
 
+                case Command.ChangeTabTitle:
+                    return new List<KeyBinding>
+                {
+                    new KeyBinding
+                    {
+                        Command = nameof(Command.ChangeTabTitle),
+                        Ctrl = true,
+                        Alt = false,
+                        Shift = true,
+                        Key = (int)ExtendedVirtualKey.N
+                    }
+                };
+
                 case Command.CloseTab:
                     return new List<KeyBinding>
                 {

--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -45,6 +45,7 @@ namespace FluentTerminal.App.ViewModels
             _keyboardCommandService = keyboardCommandService;
             _keyboardCommandService.RegisterCommandHandler(nameof(Command.NewTab), () => AddTerminal(null, false, Guid.Empty));
             _keyboardCommandService.RegisterCommandHandler(nameof(Command.ConfigurableNewTab), () => AddTerminal(null, true, Guid.Empty));
+            _keyboardCommandService.RegisterCommandHandler(nameof(Command.ChangeTabTitle), () => SelectedTerminal.EditTitle());
             _keyboardCommandService.RegisterCommandHandler(nameof(Command.CloseTab), CloseCurrentTab);
 
             // Add all of the commands for switching to a tab of a given ID, if there's one open there

--- a/FluentTerminal.App.ViewModels/TerminalViewModel.cs
+++ b/FluentTerminal.App.ViewModels/TerminalViewModel.cs
@@ -221,6 +221,15 @@ namespace FluentTerminal.App.ViewModels
             return _terminalView?.FocusTerminal();
         }
 
+        public async Task EditTitle()
+        {
+            var result = await _dialogService.ShowInputDialogAsync("Edit Title");
+            if (result != null)
+            {
+                Title = result;
+            }
+        }
+
         public async Task OnViewIsReady(ITerminalView terminalView)
         {
             _terminalView = terminalView;
@@ -404,15 +413,6 @@ namespace FluentTerminal.App.ViewModels
         private void SelectTabTheme(string name)
         {
             TabTheme = TabThemes.FirstOrDefault(t => t.Name == name);
-        }
-
-        private async Task EditTitle()
-        {
-            var result = await _dialogService.ShowInputDialogAsync("Edit Title");
-            if (result != null)
-            {
-                Title = result;
-            }
         }
 
         private async Task TryClose()

--- a/FluentTerminal.Models/Enums/Command.cs
+++ b/FluentTerminal.Models/Enums/Command.cs
@@ -19,6 +19,9 @@ namespace FluentTerminal.Models.Enums
         [Description("Configurable new tab")]
         ConfigurableNewTab,
 
+        [Description("Change tab title")]
+        ChangeTabTitle,
+
         [Description("Close tab")]
         CloseTab,
 

--- a/FluentTerminal.Models/KeyBindings.cs
+++ b/FluentTerminal.Models/KeyBindings.cs
@@ -9,6 +9,7 @@ namespace FluentTerminal.Models
         public ICollection<KeyBinding> PreviousTab { get; set; }
         public ICollection<KeyBinding> NewTab { get; set; }
         public ICollection<KeyBinding> ConfigurableNewTab { get; set; }
+        public ICollection<KeyBinding> ChangeTabTitle { get; set; }
         public ICollection<KeyBinding> CloseTab { get; set; }
         public ICollection<KeyBinding> NewWindow { get; set; }
         public ICollection<KeyBinding> ShowSettings { get; set; }


### PR DESCRIPTION
As per [the suggestion](https://github.com/felixse/FluentTerminal/issues/174#issuecomment-454673472) by @ChristianSauer. I set the default binding to <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd>.