### PR TITLE
installation switch to force context menu integration automatically

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -28,6 +28,7 @@
 
 param(
     [switch]$Force = $false,
+    [switch]$ForceContextMenu = $false,
     [switch]$GetDeveloperLicense = $false,
     [string]$CertificatePath = $null
 )
@@ -622,7 +623,7 @@ function DoStandardOperations
 
     InstallPackageWithDependencies
 
-    if (ConfirmContextMenuInstall)
+    if ($ForceContextMenu -or (ConfirmContextMenuInstall))
     {
         InstallContextMenuIntegration
     }


### PR DESCRIPTION
Allows scripted install of context menu integration with `-ForceContextMenu` switch