### PR TITLE
Add keybinding for configurable new window

### DIFF
--- a/FluentTerminal.App.Services/EventArgs/NewWindowRequestedEventArgs.cs
+++ b/FluentTerminal.App.Services/EventArgs/NewWindowRequestedEventArgs.cs
@@ -1,0 +1,7 @@
+﻿namespace FluentTerminal.App.Services.EventArgs
+{
+    public class NewWindowRequestedEventArgs : System.EventArgs
+    {
+        public bool ShowProfileSelection { get; set; }
+    }
+}

--- a/FluentTerminal.App.Services/EventArgs/ProfileSelectEventArgs.cs
+++ b/FluentTerminal.App.Services/EventArgs/ProfileSelectEventArgs.cs
@@ -1,0 +1,7 @@
+﻿namespace FluentTerminal.App.Services.EventArgs
+{
+    public class ProfileSelectEventArgs : System.EventArgs
+    {
+        public bool ShowProfileSelection { get; set; } = false;
+    }
+}

--- a/FluentTerminal.App.Services/EventArgs/ProfileSelectEventArgs.cs
+++ b/FluentTerminal.App.Services/EventArgs/ProfileSelectEventArgs.cs
@@ -1,7 +1,0 @@
-﻿namespace FluentTerminal.App.Services.EventArgs
-{
-    public class ProfileSelectEventArgs : System.EventArgs
-    {
-        public bool ShowProfileSelection { get; set; } = false;
-    }
-}

--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -156,6 +156,19 @@ namespace FluentTerminal.App.Services.Implementation
                     }
                 };
 
+                case Command.ConfigurableNewWindow:
+                    return new List<KeyBinding>
+                {
+                    new KeyBinding
+                    {
+                        Command = nameof(Command.ConfigurableNewWindow),
+                        Ctrl = true,
+                        Alt = false,
+                        Shift = true,
+                        Key = (int)ExtendedVirtualKey.N
+                    }
+                };
+
                 case Command.ShowSettings:
                     return new List<KeyBinding>
                 {

--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -182,13 +182,20 @@ namespace FluentTerminal.App.ViewModels
 
                     if (profile == null)
                     {
+                        if (Terminals.Count == 0)
+                        {
+                            Closed?.Invoke(this, EventArgs.Empty);
+                            _applicationView.TryClose();
+                        }
+
                         return;
                     }
                 }
                 else if (profileId == Guid.Empty)
                 {
                     profile = _settingsService.GetDefaultShellProfile();
-                } else
+                }
+                else
                 {
                     profile = _settingsService.GetShellProfile(profileId);
                 }

--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -104,7 +104,7 @@ namespace FluentTerminal.App.ViewModels
 
         public event EventHandler Closed;
 
-        public event EventHandler<ProfileSelectEventArgs> NewWindowRequested;
+        public event EventHandler<NewWindowRequestedEventArgs> NewWindowRequested;
 
         public event EventHandler ShowSettingsRequested;
 
@@ -224,8 +224,10 @@ namespace FluentTerminal.App.ViewModels
 
         private void NewWindow(bool showProfileSelection)
         {
-            ProfileSelectEventArgs args = new ProfileSelectEventArgs();
-            args.ShowProfileSelection = showProfileSelection;
+            var args = new NewWindowRequestedEventArgs
+            {
+                ShowProfileSelection = showProfileSelection
+            };
 
             NewWindowRequested?.Invoke(this, args);
         }

--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -60,7 +60,9 @@ namespace FluentTerminal.App.ViewModels
             _keyboardCommandService.RegisterCommandHandler(nameof(Command.NextTab), SelectNextTab);
             _keyboardCommandService.RegisterCommandHandler(nameof(Command.PreviousTab), SelectPreviousTab);
 
-            _keyboardCommandService.RegisterCommandHandler(nameof(Command.NewWindow), NewWindow);
+            _keyboardCommandService.RegisterCommandHandler(nameof(Command.NewWindow), () => NewWindow(false));
+            _keyboardCommandService.RegisterCommandHandler(nameof(Command.ConfigurableNewWindow), () => NewWindow(true));
+
             _keyboardCommandService.RegisterCommandHandler(nameof(Command.ShowSettings), ShowSettings);
             _keyboardCommandService.RegisterCommandHandler(nameof(Command.ToggleFullScreen), ToggleFullScreen);
 
@@ -102,7 +104,7 @@ namespace FluentTerminal.App.ViewModels
 
         public event EventHandler Closed;
 
-        public event EventHandler NewWindowRequested;
+        public event EventHandler<ProfileSelectEventArgs> NewWindowRequested;
 
         public event EventHandler ShowSettingsRequested;
 
@@ -213,9 +215,12 @@ namespace FluentTerminal.App.ViewModels
             SelectedTerminal?.CloseCommand.Execute(null);
         }
 
-        private void NewWindow()
+        private void NewWindow(bool showProfileSelection)
         {
-            NewWindowRequested?.Invoke(this, EventArgs.Empty);
+            ProfileSelectEventArgs args = new ProfileSelectEventArgs();
+            args.ShowProfileSelection = showProfileSelection;
+
+            NewWindowRequested?.Invoke(this, args);
         }
 
         private async void OnApplicationSettingsChanged(object sender, ApplicationSettings e)

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -4,6 +4,7 @@ using FluentTerminal.App.Dialogs;
 using FluentTerminal.App.Services;
 using FluentTerminal.App.Services.Adapters;
 using FluentTerminal.App.Services.Dialogs;
+using FluentTerminal.App.Services.EventArgs;
 using FluentTerminal.App.Services.Implementation;
 using FluentTerminal.App.ViewModels;
 using FluentTerminal.App.Views;
@@ -119,7 +120,7 @@ namespace FluentTerminal.App
                         }
                         else
                         {
-                            await CreateNewTerminalWindow(parameter).ConfigureAwait(true);
+                            await CreateNewTerminalWindow(parameter, false).ConfigureAwait(true);
                         }
                     }
                 }
@@ -151,7 +152,7 @@ namespace FluentTerminal.App
             }
             else if (_mainViewModels.Count == 0)
             {
-                await CreateSecondaryView<MainViewModel>(typeof(MainPage), true, string.Empty).ConfigureAwait(true);
+                await CreateSecondaryView<MainViewModel>(typeof(MainPage), true, false, string.Empty).ConfigureAwait(true);
             }
         }
 
@@ -212,13 +213,13 @@ namespace FluentTerminal.App
             Window.Current.Activate();
         }
 
-        private async Task CreateNewTerminalWindow(string startupDirectory)
+        private async Task CreateNewTerminalWindow(string startupDirectory, bool showProfileSelection)
         {
-            var id = await CreateSecondaryView<MainViewModel>(typeof(MainPage), true, startupDirectory).ConfigureAwait(true);
+            var id = await CreateSecondaryView<MainViewModel>(typeof(MainPage), true, showProfileSelection, startupDirectory).ConfigureAwait(true);
             await ApplicationViewSwitcher.TryShowAsStandaloneAsync(id);
         }
 
-        private async Task<int> CreateSecondaryView<TViewModel>(Type pageType, bool ExtendViewIntoTitleBar, object parameter)
+        private async Task<int> CreateSecondaryView<TViewModel>(Type pageType, bool ExtendViewIntoTitleBar, bool showProfileSelection, object parameter)
         {
             int windowId = 0;
             TViewModel viewModel = default;
@@ -242,7 +243,7 @@ namespace FluentTerminal.App
                 mainViewModel.ShowSettingsRequested += OnShowSettingsRequested;
                 mainViewModel.ShowAboutRequested += OnShowAboutRequested;
                 _mainViewModels.Add(mainViewModel);
-                await mainViewModel.AddTerminal(directory, false, Guid.Empty).ConfigureAwait(true);
+                await mainViewModel.AddTerminal(directory, showProfileSelection, Guid.Empty).ConfigureAwait(true);
             }
 
             if (viewModel is SettingsViewModel settingsViewModel)
@@ -271,9 +272,9 @@ namespace FluentTerminal.App
             }
         }
 
-        private async void OnNewWindowRequested(object sender, EventArgs e)
+        private async void OnNewWindowRequested(object sender, ProfileSelectEventArgs e)
         {
-            await CreateNewTerminalWindow(string.Empty).ConfigureAwait(true);
+            await CreateNewTerminalWindow(string.Empty, e.ShowProfileSelection).ConfigureAwait(true);
         }
 
         private void OnSettingsClosed(object sender, EventArgs e)
@@ -303,7 +304,7 @@ namespace FluentTerminal.App
         {
             if (_settingsViewModel == null)
             {
-                _settingsWindowId = await CreateSecondaryView<SettingsViewModel>(typeof(SettingsPage), true, null).ConfigureAwait(true);
+                _settingsWindowId = await CreateSecondaryView<SettingsViewModel>(typeof(SettingsPage), true, false, null).ConfigureAwait(true);
             }
             await ApplicationViewSwitcher.TryShowAsStandaloneAsync(_settingsWindowId.Value);
         }

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -272,7 +272,7 @@ namespace FluentTerminal.App
             }
         }
 
-        private async void OnNewWindowRequested(object sender, ProfileSelectEventArgs e)
+        private async void OnNewWindowRequested(object sender, NewWindowRequestedEventArgs e)
         {
             await CreateNewTerminalWindow(string.Empty, e.ShowProfileSelection).ConfigureAwait(true);
         }

--- a/FluentTerminal.Models/Enums/Command.cs
+++ b/FluentTerminal.Models/Enums/Command.cs
@@ -28,6 +28,9 @@ namespace FluentTerminal.Models.Enums
         [Description("New window")]
         NewWindow,
 
+        [Description("Configurable new window")]
+        ConfigurableNewWindow,
+
         [Description("Show settings")]
         ShowSettings,
 

--- a/FluentTerminal.Models/KeyBindings.cs
+++ b/FluentTerminal.Models/KeyBindings.cs
@@ -12,6 +12,7 @@ namespace FluentTerminal.Models
         public ICollection<KeyBinding> ChangeTabTitle { get; set; }
         public ICollection<KeyBinding> CloseTab { get; set; }
         public ICollection<KeyBinding> NewWindow { get; set; }
+        public ICollection<KeyBinding> ConfigurableNewWindow { get; set; }
         public ICollection<KeyBinding> ShowSettings { get; set; }
         public ICollection<KeyBinding> Copy { get; set; }
         public ICollection<KeyBinding> Paste { get; set; }


### PR DESCRIPTION
As per #96 and [this comment](https://github.com/felixse/FluentTerminal/pull/193#issuecomment-460706953) I added a keybinding to open a new configurable window. The default binding is <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>N</kbd>.

![preview](https://user-images.githubusercontent.com/3742559/53475081-b4c77300-3a77-11e9-9ff2-a2ec1a4bbd5f.gif)

### Alternative design

1] It may be possible to rely less on a parameter (`showProfileSelection`) in _App.xaml.cs_, but I personally don't think that's a good idea.

* * *

2] There are now two `EventArgs` (namely `CancelableEventArgs` and `ProfileSelectEventArgs`) that basically only hold a boolean value (`cancelled` and `ShowProfileSelection` respectively). On the one hand one the naming helps the reader understand the code, on the other hand it you have (albeit simple) duplicate code. I can refactor the `EventArgs` into a single `BooleanEventArgs` class like so:

```c#
// Current use of CancelableEventArgs
e.Cancelled = true;

// Example of using BooleanEventArgs
cancelable.Value = true;
```

However, the current approach forces the programmer to be descriptive, whereas the refactor would allow misuse of the `EventArgs`, like so:
```#
// Misuse of BooleanEventArgs
e.Value = true;
```