### PR TITLE
set `TERM` to `xterm-256color`

### DIFF
--- a/FluentTerminal.SystemTray/Services/TerminalsManager.cs
+++ b/FluentTerminal.SystemTray/Services/TerminalsManager.cs
@@ -108,7 +108,7 @@ namespace FluentTerminal.SystemTray.Services
         public string GetDefaultEnvironmentVariableString()
         {
             var environmentVariables = Environment.GetEnvironmentVariables();
-            environmentVariables.Add("TERM", "xterm");
+            environmentVariables.Add("TERM", "xterm-256color");
             environmentVariables.Add("TERM_PROGRAM", "FluentTerminal");
             environmentVariables.Add("TERM_PROGRAM_VERSION", $"{Package.Current.Id.Version.Major}.{Package.Current.Id.Version.Minor}.{Package.Current.Id.Version.Build}.{Package.Current.Id.Version.Revision}");
 


### PR DESCRIPTION
### Summary
This PR changes `TERM` from `xterm` to `xterm-256color` to be better consistent with other xterm.js-based Terminals

### Related
- **Hyper:** https://github.com/zeit/hyper/blob/571231e4438cae4eec3e88fa4aab398b5b269433/app/session.js#L32-L36
- **Terminus:** https://github.com/Eugeny/terminus/blob/9e81f0aa0e7274fdddc110ea9c77ca42f500896e/terminus-terminal/src/services/sessions.service.ts#L96-L101