### PR TITLE
Use idiomatic JS import style in web client

### DIFF
--- a/FluentTerminal.Client/src/index.js
+++ b/FluentTerminal.Client/src/index.js
@@ -1,9 +1,8 @@
-import * as Terminal from '../node_modules/xterm/dist/xterm';
-import * as attach from '../node_modules/xterm/dist/addons/attach/attach';
-import * as fit from '../node_modules/xterm/dist/addons/fit/fit';
-import * as winptyCompat from '../node_modules/xterm/dist/addons/winptyCompat/winptyCompat';
-import * as search from '../node_modules/xterm/dist/addons/search/search';
-
+import { Terminal } from "xterm";
+import * as attach from "xterm/lib/addons/attach/attach";
+import * as fit from "xterm/lib/addons/fit/fit";
+import * as winptyCompat from "xterm/lib/addons/winptyCompat/winptyCompat";
+import * as search from "xterm/lib/addons/search/search";
 
 Terminal.applyAddon(attach);
 Terminal.applyAddon(fit);


### PR DESCRIPTION
Add-ons imported as per Xterm documentation recommendations: https://xtermjs.org/docs/guides/using-addons/

Importing from dist in JS is implementation dependent - it is better to use the `export`ed paths, as this is the externally exposed API from the module.