### PR TITLE
Add convert line endings to CR option

### DIFF
--- a/FluentTerminal.App.ViewModels/ShellProfileViewModel.cs
+++ b/FluentTerminal.App.ViewModels/ShellProfileViewModel.cs
@@ -208,6 +208,7 @@ namespace FluentTerminal.App.ViewModels
                     _lineEndingStyle = value;
                     RaisePropertyChanged();
                     RaisePropertyChanged(nameof(DoNotModifyIsSelected));
+                    RaisePropertyChanged(nameof(ToCRIsSelected));
                     RaisePropertyChanged(nameof(ToCRLFIsSelected));
                     RaisePropertyChanged(nameof(ToLFIsSelected));
                     _editingLineEndingStyle = false;
@@ -231,6 +232,12 @@ namespace FluentTerminal.App.ViewModels
         {
             get => LineEndingStyle == LineEndingStyle.ToLF;
             set => LineEndingStyle = LineEndingStyle.ToLF;
+        }
+
+        public bool ToCRIsSelected
+        {
+            get => LineEndingStyle == LineEndingStyle.ToCR;
+            set => LineEndingStyle = LineEndingStyle.ToCR;
         }
 
         public void SaveChanges()

--- a/FluentTerminal.App/Views/SettingsPages/ShellProfileSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/ShellProfileSettings.xaml
@@ -289,13 +289,13 @@
                                         GroupName="LineEndingStyle"
                                         IsChecked="{x:Bind DoNotModifyIsSelected, Mode=TwoWay}" />
                                     <RadioButton
-                                        Content="Convert line endings to CR"
-                                        GroupName="LineEndingStyle"
-                                        IsChecked="{x:Bind ToCRIsSelected, Mode=TwoWay}" />
-                                    <RadioButton
                                         Content="Convert line endings to CR+LF"
                                         GroupName="LineEndingStyle"
                                         IsChecked="{x:Bind ToCRLFIsSelected, Mode=TwoWay}" />
+                                    <RadioButton
+                                        Content="Convert line endings to CR"
+                                        GroupName="LineEndingStyle"
+                                        IsChecked="{x:Bind ToCRIsSelected, Mode=TwoWay}" />
                                     <RadioButton
                                         Content="Convert line endings to LF"
                                         GroupName="LineEndingStyle"

--- a/FluentTerminal.App/Views/SettingsPages/ShellProfileSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/ShellProfileSettings.xaml
@@ -289,6 +289,10 @@
                                         GroupName="LineEndingStyle"
                                         IsChecked="{x:Bind DoNotModifyIsSelected, Mode=TwoWay}" />
                                     <RadioButton
+                                        Content="Convert line endings to CR"
+                                        GroupName="LineEndingStyle"
+                                        IsChecked="{x:Bind ToCRIsSelected, Mode=TwoWay}" />
+                                    <RadioButton
                                         Content="Convert line endings to CR+LF"
                                         GroupName="LineEndingStyle"
                                         IsChecked="{x:Bind ToCRLFIsSelected, Mode=TwoWay}" />

--- a/FluentTerminal.Models/Enums/LineEndingStyle.cs
+++ b/FluentTerminal.Models/Enums/LineEndingStyle.cs
@@ -7,6 +7,9 @@ namespace FluentTerminal.Models.Enums
         [Description("Do not modify")]
         DoNotModify,
 
+        [Description("Convert to CR")]
+        ToCR,
+
         [Description("Convert to CRLF")]
         ToCRLF,
 

--- a/FluentTerminal.Models/ShellProfile.cs
+++ b/FluentTerminal.Models/ShellProfile.cs
@@ -45,6 +45,8 @@ namespace FluentTerminal.Models
         {
             switch (LineEndingTranslation)
             {
+                case LineEndingStyle.ToCR:
+                    return NewlinePattern.Replace(content, "\r");
                 case LineEndingStyle.ToCRLF:
                     return NewlinePattern.Replace(content, "\r\n");
                 case LineEndingStyle.ToLF:


### PR DESCRIPTION
I've been unable to use multi-line paste in interactive terminal programs (e.g. nano editor) as it expects to see the [Enter] key as [CR].
Sending pasted line-endings as [CR] also still works for all my non-interactive situations, as the default WSL Ubuntu 16/18 `stty icrnl` configuration will convert [CR] to [LF].