### PR TITLE
move the $null to the left side of the operator

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -328,7 +328,7 @@ function CheckIfNeedToEnableSideloading
     if (Test-Path $RegistryPath)
     {
         $SideloadingEnabledProperty = (Get-ItemProperty -Path $RegistryPath -Name $ValueName -ErrorAction SilentlyContinue)
-        if ($SideloadingEnabledProperty -ne $null -and $SideloadingEnabledProperty.$ValueName -eq 1)
+        if ($null -ne $SideloadingEnabledProperty -and $SideloadingEnabledProperty.$ValueName -eq 1)
         {
             $Result = $false
         }


### PR DESCRIPTION
I saw in the install PowerShell script, at line 331, there is a comparison with a right hand null element. This will produce a warning, because PowerShell might not do the comparisons correctly if the $null element is not on the left side. You can read why from the link below (see below). This PR is to remove the warning 

https://github.com/PowerShell/PSScriptAnalyzer/blob/development/RuleDocumentation/PossibleIncorrectComparisonWithNull.md


![image](https://user-images.githubusercontent.com/6210337/55047004-455e8800-5011-11e9-8c51-5e9c97ecdca6.png)

