### PR TITLE
Read whole terminal frame at once to avoid console data append glitches

### DIFF
--- a/FluentTerminal.SystemTray/Services/ConPty/ConPtySession.cs
+++ b/FluentTerminal.SystemTray/Services/ConPty/ConPtySession.cs
@@ -83,8 +83,7 @@ namespace FluentTerminal.SystemTray.Services.ConPty
                 {
                     do
                     {
-                        int bufferSize = 1024 > _terminalSize.Columns * _terminalSize.Rows * 4 ? 1024 : _terminalSize.Columns * _terminalSize.Rows * 4;
-                        var buffer = new byte[bufferSize];
+                        var buffer = new byte[Math.Max(1024, _terminalSize.Columns * _terminalSize.Rows * 4)];
                         var readBytes = await _terminal.ConsoleOutStream.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
                         var read = new byte[readBytes];
                         Buffer.BlockCopy(buffer, 0, read, 0, readBytes);

--- a/FluentTerminal.SystemTray/Services/WinPty/WinPtySession.cs
+++ b/FluentTerminal.SystemTray/Services/WinPty/WinPtySession.cs
@@ -201,8 +201,7 @@ namespace FluentTerminal.SystemTray.Services.WinPty
                 {
                     do
                     {
-                        int bufferSize = 1024 > _terminalSize.Columns * _terminalSize.Rows * 4 ? 1024 : _terminalSize.Columns * _terminalSize.Rows * 4;
-                        var buffer = new byte[bufferSize];
+                        var buffer = new byte[Math.Max(1024, _terminalSize.Columns * _terminalSize.Rows * 4)];
                         var readBytes = await _stdout.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
                         var read = new byte[readBytes];
                         Buffer.BlockCopy(buffer, 0, read, 0, readBytes);

--- a/FluentTerminal.SystemTray/Services/WinPty/WinPtySession.cs
+++ b/FluentTerminal.SystemTray/Services/WinPty/WinPtySession.cs
@@ -23,11 +23,13 @@ namespace FluentTerminal.SystemTray.Services.WinPty
         private TerminalsManager _terminalsManager;
         private Process _shellProcess;
         private bool _exited;
+        private TerminalSize _terminalSize;
 
         public void Start(CreateTerminalRequest request, TerminalsManager terminalsManager)
         {
             Id = request.Id;
             _terminalsManager = terminalsManager;
+            _terminalSize = request.Size;
 
             var configHandle = IntPtr.Zero;
             var spawnConfigHandle = IntPtr.Zero;
@@ -145,6 +147,7 @@ namespace FluentTerminal.SystemTray.Services.WinPty
                 {
                     throw new Exception(winpty_error_msg(errorHandle));
                 }
+                _terminalSize = size;
             }
             finally
             {
@@ -198,7 +201,8 @@ namespace FluentTerminal.SystemTray.Services.WinPty
                 {
                     do
                     {
-                        var buffer = new byte[1024];
+                        int bufferSize = 1024 > _terminalSize.Columns * _terminalSize.Rows * 4 ? 1024 : _terminalSize.Columns * _terminalSize.Rows * 4;
+                        var buffer = new byte[bufferSize];
                         var readBytes = await _stdout.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
                         var read = new byte[readBytes];
                         Buffer.BlockCopy(buffer, 0, read, 0, readBytes);


### PR DESCRIPTION
Fixes console output rendering [issues ](https://github.com/jumptrading/FluentTerminal/issues/13) that appear on whole buffer frame update (happens on usage of tmux, mosh).

More details:

- Similar issues happen both for ConPTY and WinPTY on running `tmux`
- Issue disappears if to increase output std reading buffer. But if to resize the terminal to exceed the buffer the issue come back again. 
- "Unexpected" characters appear between calls of `_appServiceConnection.SendMessageAsync(CreateMessage(e));`
![2019-04-07_1-30-41-console-message-issue](https://user-images.githubusercontent.com/1928902/55676218-efbf9080-58d8-11e9-9d91-d43f4799b83b.gif)

Changes in PR read output console stream for whole terminal buffer at once to execute `_appServiceConnection.SendMessageAsync` only single time per "frame".