### PR TITLE
Fix finding SSH when run as 32-bit process on a 64-bit OS

### DIFF
--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -234,11 +234,11 @@ namespace FluentTerminal.App.ViewModels
                     return;
                 }
 
-                var profile = new ShellProfile
+                var profile = new SshProfile
                 {
-                    Arguments = $"-p {connectionInfo.Port:#####} {connectionInfo.Username}@{connectionInfo.Host}",
-                    Location = @"C:\Windows\System32\OpenSSH\ssh.exe",
-                    WorkingDirectory = string.Empty,
+                    Username = connectionInfo.Username,
+                    Host = connectionInfo.Host,
+                    Port = connectionInfo.Port,
                     LineEndingTranslation = LineEndingStyle.DoNotModify,
                 };
 

--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -242,7 +242,15 @@ namespace FluentTerminal.App.ViewModels
                     LineEndingTranslation = LineEndingStyle.DoNotModify,
                 };
 
-                AddTerminal(profile);
+                var error = profile.ValidateAndGetErrors();
+                if( ! String.IsNullOrEmpty(error) )
+                {
+                    await _dialogService.ShowMessageDialogAsnyc("Error", "The operation cannot be completed due to the following error: " + error, DialogButton.OK).ConfigureAwait(false);
+                }
+                else
+                {
+                    AddTerminal(profile);
+                }
             });
         }
 

--- a/FluentTerminal.Models/ShellProfile.cs
+++ b/FluentTerminal.Models/ShellProfile.cs
@@ -35,8 +35,8 @@ namespace FluentTerminal.Models
         public Guid Id { get; set; }
         public bool PreInstalled { get; set; }
         public string Name { get; set; }
-        public string Arguments { get; set; }
-        public string Location { get; set; }
+        public virtual string Arguments { get; set; }
+        public virtual string Location { get; set; }
         public string WorkingDirectory { get; set; }
         public int TabThemeId { get; set; }
         public LineEndingStyle LineEndingTranslation { get; set; }

--- a/FluentTerminal.Models/ShellProfile.cs
+++ b/FluentTerminal.Models/ShellProfile.cs
@@ -77,5 +77,14 @@ namespace FluentTerminal.Models
             }
             return false;
         }
+
+        /// <summary>
+        /// Checks the profile for errors and returns string describing the found errors, if any.
+        /// Returns null if no errors found.
+        /// </summary>
+        public virtual string ValidateAndGetErrors()
+        {
+            return null;
+        }
     }
 }

--- a/FluentTerminal.Models/SshProfile.cs
+++ b/FluentTerminal.Models/SshProfile.cs
@@ -7,9 +7,33 @@ namespace FluentTerminal.Models
 {
     public class SshProfile: ShellProfile
     {
+        private string _sshLocation;
+
         public SshProfile()
         {
             WorkingDirectory = string.Empty;
+
+            _sshLocation = getSshLocation();
+        }
+
+        private string getSshLocation()
+        {
+            //
+            // See https://stackoverflow.com/a/25919981
+            //
+
+            string system32Folder;
+
+            if (Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess)
+            {
+                system32Folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), @"Sysnative");
+            }
+            else
+            {
+                system32Folder = Environment.GetFolderPath(Environment.SpecialFolder.System);
+            }
+
+            return Path.Combine(system32Folder, @"OpenSSH\ssh.exe");
         }
 
         public override string Arguments
@@ -24,23 +48,20 @@ namespace FluentTerminal.Models
         {
             get
             {
-                //
-                // See https://stackoverflow.com/a/25919981
-                //
-
-                string system32Folder;
-
-                if(Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess)
-                {
-                    system32Folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), @"Sysnative");
-                }
-                else
-                {
-                    system32Folder = Environment.GetFolderPath(Environment.SpecialFolder.System);
-                }
-
-                return Path.Combine(system32Folder, @"OpenSSH\ssh.exe");
+                return _sshLocation;
             }
+        }
+
+        public override string ValidateAndGetErrors()
+        {
+            string result = null;
+
+            if( !System.IO.File.Exists(_sshLocation) )
+            {
+                result = "The OpenSSH client seems not installed on this machine";
+            }
+
+            return result;
         }
 
         public ushort Port { get; set; }

--- a/FluentTerminal.Models/SshProfile.cs
+++ b/FluentTerminal.Models/SshProfile.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace FluentTerminal.Models
+{
+    public class SshProfile: ShellProfile
+    {
+        public SshProfile()
+        {
+            WorkingDirectory = string.Empty;
+        }
+
+        public override string Arguments
+        {
+            get
+            {
+                return $"-p {Port:#####} {Username}@{Host}";
+            }
+        }
+
+        public override string Location
+        {
+            get
+            {
+                //
+                // See https://stackoverflow.com/a/25919981
+                //
+
+                string system32Folder;
+
+                if(Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess)
+                {
+                    system32Folder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), @"Sysnative");
+                }
+                else
+                {
+                    system32Folder = Environment.GetFolderPath(Environment.SpecialFolder.System);
+                }
+
+                return Path.Combine(system32Folder, @"OpenSSH\ssh.exe");
+            }
+        }
+
+        public ushort Port { get; set; }
+        public string Username { get; set; }
+        public string Host { get; set; }
+    }
+}


### PR DESCRIPTION
Now FluentTerminal correctly finds `ssh.exe` when run as a 32-bit process on 64-bit operational system.
Also, now to find paths to system directories it uses system calls instead of using hardcoded paths.