### PR TITLE
Bubble up shell process exit codes

### DIFF
--- a/FluentTerminal.App.Services.Test/TrayProcessCommunicationServiceTests.cs
+++ b/FluentTerminal.App.Services.Test/TrayProcessCommunicationServiceTests.cs
@@ -114,13 +114,10 @@ namespace FluentTerminal.App.Services.Test
         [Fact]
         public void OnMessageReceived_TerminalExitedRequest_InvokesTerminalExitedEvent()
         {
-            var terminalId = _fixture.Create<int>();
-            var receivedTerminalId = 0;
-            var terminalExitedEventCalled = false;
-            var request = new TerminalExitedRequest
-            {
-                TerminalId = terminalId
-            };
+            var request = new TerminalExitedRequest(_fixture.Create<int>(), _fixture.Create<int>());
+
+            var receivedExitStatus = (TerminalExitStatus) null;
+
             var message = new Dictionary<string, string>
             {
                 [MessageKeys.Type] = nameof(TerminalExitedRequest),
@@ -135,16 +132,16 @@ namespace FluentTerminal.App.Services.Test
             var trayProcessCommunicationService = new TrayProcessCommunicationService(settingsService.Object);
             var appServiceConnection = new Mock<IAppServiceConnection>();
             trayProcessCommunicationService.Initialize(appServiceConnection.Object);
-            trayProcessCommunicationService.TerminalExited += (s, e) =>
+            trayProcessCommunicationService.TerminalExited += (s, status) =>
             {
-                terminalExitedEventCalled = true;
-                receivedTerminalId = e;
+                receivedExitStatus = status;
             };
 
             appServiceConnection.Raise(x => x.MessageReceived += null, null, message);
 
-            terminalExitedEventCalled.Should().BeTrue();
-            receivedTerminalId.Should().Be(terminalId);
+            receivedExitStatus.Should().NotBeNull();
+            receivedExitStatus.TerminalId.Should().Be(request.TerminalId);
+            receivedExitStatus.ExitCode.Should().Be(request.ExitCode);
         }
 
         [Fact]

--- a/FluentTerminal.App.Services/ITrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/ITrayProcessCommunicationService.cs
@@ -8,7 +8,7 @@ namespace FluentTerminal.App.Services
 {
     public interface ITrayProcessCommunicationService
     {
-        event EventHandler<int> TerminalExited;
+        event EventHandler<TerminalExitStatus> TerminalExited;
 
         void Initialize(IAppServiceConnection appServiceConnection);
 

--- a/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
@@ -16,7 +16,7 @@ namespace FluentTerminal.App.Services.Implementation
         private readonly Dictionary<int, Action<byte[]>> _terminalOutputHandlers;
         private int _nextTerminalId = 0;
 
-        public event EventHandler<int> TerminalExited;
+        public event EventHandler<TerminalExitStatus> TerminalExited;
 
         public TrayProcessCommunicationService(ISettingsService settingsService)
         {
@@ -88,10 +88,9 @@ namespace FluentTerminal.App.Services.Implementation
             else if (messageType == nameof(TerminalExitedRequest))
             {
                 var request = JsonConvert.DeserializeObject<TerminalExitedRequest>(messageContent);
-
                 Logger.Instance.Debug("Received TerminalExitedRequest: {@request}", request);
 
-                TerminalExited?.Invoke(this, request.TerminalId);
+                TerminalExited?.Invoke(this, request.ToStatus());
             }
         }
 
@@ -136,10 +135,7 @@ namespace FluentTerminal.App.Services.Implementation
 
         public Task CloseTerminal(int terminalId)
         {
-            var request = new TerminalExitedRequest
-            {
-                TerminalId = terminalId
-            };
+            var request = new TerminalExitedRequest(terminalId, -1);
 
             Logger.Instance.Debug("Sending TerminalExitedRequest: {@request}", request);
 

--- a/FluentTerminal.App.Services/Terminal.cs
+++ b/FluentTerminal.App.Services/Terminal.cs
@@ -18,9 +18,9 @@ namespace FluentTerminal.App.Services
             Id = _trayProcessCommunicationService.GetNextTerminalId();
         }
 
-        private void OnTerminalExited(object sender, int e)
+        private void OnTerminalExited(object sender, TerminalExitStatus status)
         {
-            if (e == Id)
+            if (status.TerminalId == Id)
             {
                 Closed?.Invoke(this, System.EventArgs.Empty);
             }

--- a/FluentTerminal.Models/Requests/TerminalExitedRequest.cs
+++ b/FluentTerminal.Models/Requests/TerminalExitedRequest.cs
@@ -1,7 +1,40 @@
 ﻿namespace FluentTerminal.Models.Requests
 {
-    public class TerminalExitedRequest
-    {
+    public class TerminalExitedRequest {
+
         public int TerminalId { get; set; }
+        public int ExitCode { get; set; }
+
+        public TerminalExitedRequest(int terminalId, int exitCode)
+        {
+            TerminalId = terminalId;
+            ExitCode = exitCode;
+        }
+
+        public TerminalExitedRequest(int terminalId)
+        {
+            TerminalId = terminalId;
+            ExitCode = -1;
+        }
+
+        // This is for JSON deserialisation.
+        public TerminalExitedRequest()
+        {
+            TerminalId = -1;
+            ExitCode = -2;
+        }
+
+        // Create a TerminalExitedRequest from a TerminalExitStatus.
+        public TerminalExitedRequest(TerminalExitStatus status)
+        {
+            TerminalId = status.TerminalId;
+            ExitCode = status.ExitCode;
+        }
+
+        // Convert to a TerminalExitStatus.
+        public TerminalExitStatus ToStatus()
+        {
+            return new TerminalExitStatus(TerminalId, ExitCode);
+        }
     }
 }

--- a/FluentTerminal.Models/TerminalExitStatus.cs
+++ b/FluentTerminal.Models/TerminalExitStatus.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FluentTerminal.Models
+{
+    public class TerminalExitStatus
+    {
+        public TerminalExitStatus(int terminalId, int exitCode)
+        {
+            TerminalId = terminalId;
+            ExitCode = exitCode;
+        }
+
+        public int TerminalId { get; set; }
+        public int ExitCode { get; set; }
+    }
+}

--- a/FluentTerminal.SystemTray/Native/ProcessApi.cs
+++ b/FluentTerminal.SystemTray/Native/ProcessApi.cs
@@ -7,5 +7,8 @@ namespace FluentTerminal.SystemTray.Native
     {
         [DllImport("kernel32.dll")]
         public static extern int GetProcessId(IntPtr handle);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool GetExitCodeProcess(IntPtr hProcess, out uint ExitCode);
     }
 }

--- a/FluentTerminal.SystemTray/Services/AppCommunicationService.cs
+++ b/FluentTerminal.SystemTray/Services/AppCommunicationService.cs
@@ -39,13 +39,9 @@ namespace FluentTerminal.SystemTray.Services
             });
         }
 
-        private void _terminalsManager_TerminalExited(object sender, int e)
+        private void _terminalsManager_TerminalExited(object sender, TerminalExitStatus status)
         {
-            var request = new TerminalExitedRequest
-            {
-                TerminalId = e
-            };
-
+            var request = new TerminalExitedRequest(status);
             _appServiceConnection?.SendMessageAsync(CreateMessage(request));
         }
 

--- a/FluentTerminal.SystemTray/Services/ConPty/ConPtySession.cs
+++ b/FluentTerminal.SystemTray/Services/ConPty/ConPtySession.cs
@@ -1,8 +1,8 @@
-﻿using FluentTerminal.Models;
-using FluentTerminal.Models.Requests;
-using System;
+﻿using System;
 using System.IO;
 using System.Threading.Tasks;
+using FluentTerminal.Models;
+using FluentTerminal.Models.Requests;
 
 namespace FluentTerminal.SystemTray.Services.ConPty
 {
@@ -17,11 +17,11 @@ namespace FluentTerminal.SystemTray.Services.ConPty
 
         public string ShellExecutableName { get; private set; }
 
-        public event EventHandler ConnectionClosed;
+        public event EventHandler<int> ConnectionClosed;
 
         public void Close()
         {
-            ConnectionClosed?.Invoke(this, EventArgs.Empty);
+            ConnectionClosed?.Invoke(this, _terminal.ExitCode);
         }
 
         public void Resize(TerminalSize size)

--- a/FluentTerminal.SystemTray/Services/ConPty/Processes/Process.cs
+++ b/FluentTerminal.SystemTray/Services/ConPty/Processes/Process.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
+using static FluentTerminal.SystemTray.Native.ProcessApi;
 using static FluentTerminal.SystemTray.Services.ConPty.Native.ProcessApi;
 
 namespace FluentTerminal.SystemTray.Services.ConPty.Processes
@@ -17,6 +19,17 @@ namespace FluentTerminal.SystemTray.Services.ConPty.Processes
 
         public STARTUPINFOEX StartupInfo { get; }
         public PROCESS_INFORMATION ProcessInfo { get; }
+
+        /// <summary>
+        /// Returns the exit code for the process.
+        /// </summary>
+        public uint GetExitCode() {
+            if (!GetExitCodeProcess(ProcessInfo.hProcess, out uint exitCode))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "could not retrieve process exit code");
+            }
+            return exitCode;
+        }
 
         #region IDisposable Support
 

--- a/FluentTerminal.SystemTray/Services/ConPty/Terminal.cs
+++ b/FluentTerminal.SystemTray/Services/ConPty/Terminal.cs
@@ -1,12 +1,12 @@
-﻿using FluentTerminal.SystemTray.Services.ConPty.Processes;
-using Microsoft.Win32.SafeHandles;
+﻿using Microsoft.Win32.SafeHandles;
 using System;
 using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
-using static FluentTerminal.SystemTray.Services.ConPty.Native.ConsoleApi;
+using FluentTerminal.SystemTray.Services.ConPty.Processes;
 using static FluentTerminal.SystemTray.Native.WindowApi;
+using static FluentTerminal.SystemTray.Services.ConPty.Native.ConsoleApi;
 
 namespace FluentTerminal.SystemTray.Services.ConPty
 {
@@ -31,6 +31,11 @@ namespace FluentTerminal.SystemTray.Services.ConPty
         /// </summary>
         public event EventHandler OutputReady;
         public event EventHandler Exited;
+
+        /// <summary>
+        /// The exit code of the terminal's process. -1 if the process hasn't exited yet.
+        /// </summary>
+        public int ExitCode { get; private set; } = -1;
 
         public Terminal()
         {
@@ -95,6 +100,7 @@ namespace FluentTerminal.SystemTray.Services.ConPty
                 OnClose(() => DisposeResources(process, _pseudoConsole, _outputPipe, _inputPipe, _consoleInputWriter));
 
                 WaitForExit(process).WaitOne(Timeout.Infinite);
+                this.ExitCode = (int)process.GetExitCode();
             }
             Exited?.Invoke(this, EventArgs.Empty);
         }

--- a/FluentTerminal.SystemTray/Services/ITerminalSession.cs
+++ b/FluentTerminal.SystemTray/Services/ITerminalSession.cs
@@ -9,7 +9,7 @@ namespace FluentTerminal.SystemTray.Services
         int Id { get; }
         string ShellExecutableName { get; }
 
-        event EventHandler ConnectionClosed;
+        event EventHandler<int> ConnectionClosed;
 
         void Close();
         void Resize(TerminalSize size);

--- a/FluentTerminal.SystemTray/Services/TerminalsManager.cs
+++ b/FluentTerminal.SystemTray/Services/TerminalsManager.cs
@@ -21,7 +21,7 @@ namespace FluentTerminal.SystemTray.Services
 
         public event EventHandler<DisplayTerminalOutputRequest> DisplayOutputRequested;
 
-        public event EventHandler<int> TerminalExited;
+        public event EventHandler<TerminalExitStatus> TerminalExited;
 
         public TerminalsManager(ISettingsService settingsService)
         {
@@ -123,13 +123,13 @@ namespace FluentTerminal.SystemTray.Services
             return builder.ToString();
         }
 
-        private void OnTerminalConnectionClosed(object sender, System.EventArgs e)
+        private void OnTerminalConnectionClosed(object sender, int exitcode)
         {
             if (sender is ITerminalSession terminal)
             {
                 _terminals.Remove(terminal.Id);
                 terminal.Dispose();
-                TerminalExited?.Invoke(this, terminal.Id);
+                TerminalExited?.Invoke(this, new TerminalExitStatus(terminal.Id, exitcode));
             }
         }
     }

--- a/FluentTerminal.SystemTray/Services/WinPty/WinPtySession.cs
+++ b/FluentTerminal.SystemTray/Services/WinPty/WinPtySession.cs
@@ -2,14 +2,10 @@
 using FluentTerminal.Models.Requests;
 using FluentTerminal.SystemTray.Native;
 using System;
-using System.Collections;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Windows.ApplicationModel;
 using static winpty.WinPty;
 
 namespace FluentTerminal.SystemTray.Services.WinPty
@@ -114,7 +110,7 @@ namespace FluentTerminal.SystemTray.Services.WinPty
             return configuration.WorkingDirectory;
         }
 
-        public event EventHandler ConnectionClosed;
+        public event EventHandler<int> ConnectionClosed;
 
         public int Id { get; private set; }
 
@@ -129,7 +125,12 @@ namespace FluentTerminal.SystemTray.Services.WinPty
 
         public void Close()
         {
-            ConnectionClosed?.Invoke(this, EventArgs.Empty);
+            int exitCode = -1;
+            if (_shellProcess != null && _shellProcess.HasExited)
+            {
+                exitCode = _shellProcess.ExitCode;
+            }
+            ConnectionClosed?.Invoke(this, exitCode);
         }
 
         public void Write(byte[] data)


### PR DESCRIPTION
Make the shell process's exit code available to the main app so that
actions can be taken depending on whether the shell command was
successful or not.

Later work will build on this so that failed commands will result in
tabs being left open when the shell command fails. This will help when
troubleshooting incorrectly configured profiles, SSH connection issues
etc.

Exit codes are passed up for both WinPty and ConPty based terminals.