### PR TITLE
Updated default line ending for WSL to address issue #310

### DIFF
--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -408,7 +408,7 @@ namespace FluentTerminal.App.Services.Implementation
                     Location = @"C:\windows\system32\wsl.exe",
                     PreInstalled = true,
                     WorkingDirectory = string.Empty,
-                    LineEndingTranslation = LineEndingStyle.DoNotModify,
+                    LineEndingTranslation = LineEndingStyle.ToLF,
                     KeyBindings = new []
                     {
                         new KeyBinding


### PR DESCRIPTION
As per the subject, I believe changing the line style ending default for WSL should address issue #310.  Unix terminals typically expect a LF ending and windows will default generally to CR+LF.  At least in my testing changing to LF fixes the multi-line copy paste issue, so suggest changing the default for WSL.