### PR TITLE
Leave tabs open on error

### DIFF
--- a/FluentTerminal.App.Services/Terminal.cs
+++ b/FluentTerminal.App.Services/Terminal.cs
@@ -10,6 +10,8 @@ namespace FluentTerminal.App.Services
     {
         private readonly ITrayProcessCommunicationService _trayProcessCommunicationService;
         private Func<Task<string>> _selectedTextCallback;
+        private bool _closingFromUI = false;
+        private bool _exited = false;
 
         public Terminal(ITrayProcessCommunicationService trayProcessCommunicationService)
         {
@@ -20,10 +22,12 @@ namespace FluentTerminal.App.Services
 
         private void OnTerminalExited(object sender, TerminalExitStatus status)
         {
-            if (status.TerminalId == Id)
+            if (status.TerminalId == Id &&
+                (_closingFromUI == true || status.ExitCode == 0 || status.ExitCode == -1))
             {
                 Closed?.Invoke(this, System.EventArgs.Empty);
             }
+            _exited = true;
         }
 
         /// <summary>
@@ -60,6 +64,12 @@ namespace FluentTerminal.App.Services
         /// </summary>
         public async Task Close()
         {
+            if (_exited)
+            {
+                Closed?.Invoke(this, System.EventArgs.Empty);
+                return;
+            }
+            _closingFromUI = true;
             await _trayProcessCommunicationService.CloseTerminal(Id).ConfigureAwait(true);
         }
 

--- a/FluentTerminal.App.Services/Terminal.cs
+++ b/FluentTerminal.App.Services/Terminal.cs
@@ -22,13 +22,18 @@ namespace FluentTerminal.App.Services
 
         private void OnTerminalExited(object sender, TerminalExitStatus status)
         {
-            if (status.TerminalId == Id &&
-                (_closingFromUI == true || status.ExitCode == 0 || status.ExitCode == -1))
+            if (status.TerminalId != Id) return;
+
+            _exited = true;
+            Exited?.Invoke(this, status.ExitCode);
+
+            if (_closingFromUI == true || status.ExitCode <= 0)
             {
                 Closed?.Invoke(this, System.EventArgs.Empty);
             }
-            _exited = true;
         }
+
+        public event EventHandler<int> Exited;
 
         /// <summary>
         /// To be observed by both view and viewmodel

--- a/FluentTerminal.App.ViewModels/TerminalViewModel.cs
+++ b/FluentTerminal.App.ViewModels/TerminalViewModel.cs
@@ -18,6 +18,7 @@ namespace FluentTerminal.App.ViewModels
         private readonly IKeyboardCommandService _keyboardCommandService;
         private bool _isSelected;
         private bool _hasNewOutput;
+        private bool _hasExitedWithError;
         private string _searchText;
         private bool _showSearchPanel;
         private TabTheme _tabTheme;
@@ -65,6 +66,7 @@ namespace FluentTerminal.App.ViewModels
             Terminal.OutputReceived += Terminal_OutputReceived;
             Terminal.SizeChanged += Terminal_SizeChanged;
             Terminal.TitleChanged += Terminal_TitleChanged;
+            Terminal.Exited += Terminal_Exited;
             Terminal.Closed += Terminal_Closed;
 
             Overlay = new OverlayViewModel(dispatcherTimer);
@@ -133,6 +135,12 @@ namespace FluentTerminal.App.ViewModels
         {
             get => _hasNewOutput;
             set => Set(ref _hasNewOutput, value);
+        }
+
+        public bool HasExitedWithError
+        {
+            get => _hasExitedWithError;
+            set => Set(ref _hasExitedWithError, value);
         }
 
         public string SearchText
@@ -294,6 +302,11 @@ namespace FluentTerminal.App.ViewModels
         private void SelectTabTheme(string name)
         {
             TabTheme = TabThemes.FirstOrDefault(t => t.Name == name);
+        }
+
+        private void Terminal_Exited(object sender, int exitCode)
+        {
+            ApplicationView.RunOnDispatcherThread(() => HasExitedWithError = exitCode > 0);
         }
 
         private void Terminal_Closed(object sender, EventArgs e)

--- a/FluentTerminal.App/Views/TabBar.xaml
+++ b/FluentTerminal.App/Views/TabBar.xaml
@@ -176,11 +176,27 @@
                                 Text="{x:Bind TabTitle, Mode=OneWay}"
                                 TextTrimming="CharacterEllipsis"
                                 TextWrapping="NoWrap" />
-                            <Grid
+                            <StackPanel
                                 x:Name="CloseButton"
                                 Grid.Column="2"
-                                Width="32"
+                                Height="32"
+                                Orientation="Horizontal"
+                                VerticalAlignment="Center"
+                                Margin="3,0,3,0"
                                 RelativePanel.AlignRightWithPanel="True">
+                                <Viewbox Visibility="{x:Bind HasExitedWithError, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}"
+                                    Width="12"
+                                    Height="12"
+                                    ToolTipService.ToolTip="Exited with error">
+                                    <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE814;" />
+                                </Viewbox>
+                                <Viewbox Visibility="{x:Bind HasNewOutput, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}"
+                                    Width="12"
+                                    Height="12"
+                                    VerticalAlignment="Center"
+                                    ToolTipService.ToolTip="New output">
+                                    <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xEA38;" />
+                                </Viewbox>
                                 <Button
                                     HorizontalAlignment="Center"
                                     Command="{x:Bind CloseCommand}"
@@ -191,16 +207,7 @@
                                         <SymbolIcon Symbol="Cancel" />
                                     </Viewbox>
                                 </Button>
-                                <Grid Height="32" Visibility="{x:Bind HasNewOutput, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}">
-                                    <Viewbox
-                                        Width="12"
-                                        Height="12"
-                                        VerticalAlignment="Center"
-                                        ToolTipService.ToolTip="New output">
-                                        <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xEA38;" />
-                                    </Viewbox>
-                                </Grid>
-                            </Grid>
+                            </StackPanel>
                         </RelativePanel>
                     </DataTemplate>
                 </ListView.ItemTemplate>


### PR DESCRIPTION
Do not close tab if shell process closes with an error. An indicator is shown in the tab's title when this happens.

Example:

![image](https://user-images.githubusercontent.com/14993/57269268-e6456600-70da-11e9-8c9d-c76c64e1558a.png)
