### PR TITLE
Force log file creation with Initialization log message of the highes…

### DIFF
--- a/FluentTerminal.App.Services/Logger.cs
+++ b/FluentTerminal.App.Services/Logger.cs
@@ -35,7 +35,9 @@ namespace FluentTerminal.App.Services
             .MinimumLevel.Is((LogEventLevel)configuration.LogLevel)
             .CreateLogger();
 
-            Log.Information("Initialized");
+            // Log file is not created during unhandled exception processing.
+            // Force log file creation with the highest severity initialization record.
+            Log.Fatal("Initialized");
         }
 
         public void Debug(string text, params object[] propertyValues)


### PR DESCRIPTION
… severity.

More background:

Unhandled exception is logged with Error severity, but the log file is missed (default `Error` log severity setting is used).
Changing severity for "Initialize" message to the highest available forces log file creation. In that case unhandled exception information logged into pre-created file without issues.