### PR TITLE
Standardize default mosh ports to the range of 60001:60999

### DIFF
--- a/FluentTerminal.App.ViewModels/SshConnectionInfoViewModel.cs
+++ b/FluentTerminal.App.ViewModels/SshConnectionInfoViewModel.cs
@@ -8,8 +8,8 @@ namespace FluentTerminal.App.ViewModels
     public class SshConnectionInfoViewModel : ViewModelBase, ISshConnectionInfo
     {
         public const ushort DefaultSshPort = 22;
-        public const ushort DefaultMoshPortsFrom = 60000;
-        public const ushort DefaultMoshPortsTo = 60050;
+        public const ushort DefaultMoshPortsFrom = 60001;
+        public const ushort DefaultMoshPortsTo = 60999;
 
         private string _host = string.Empty;
 


### PR DESCRIPTION
To avoid extra reconfiguration of opened mosh ports the default mosh ports should be used by FT