### PR TITLE
Fixed a bug with clicking links without having the app opened.

### DIFF
--- a/FluentTerminal.App.Services/ISshConnectionInfo.cs
+++ b/FluentTerminal.App.Services/ISshConnectionInfo.cs
@@ -18,6 +18,8 @@ namespace FluentTerminal.App.Services
 
         ushort MoshPortTo { get; set; }
 
+        LineEndingStyle LineEndingStyle { get; set; }
+
         SshConnectionInfoValidationResult Validate(bool allowNoUser = false);
     }
 }

--- a/FluentTerminal.App.Services/ISshHelperService.cs
+++ b/FluentTerminal.App.Services/ISshHelperService.cs
@@ -8,9 +8,11 @@ namespace FluentTerminal.App.Services
     {
         bool IsSsh(Uri uri);
 
-        Task<ShellProfile> GetSshShellProfileAsync();
+        ISshConnectionInfo ParseSsh(Uri uri);
 
-        Task<ShellProfile> GetSshShellProfileAsync(Uri uri);
+        ShellProfile CreateShellProfile(ISshConnectionInfo sshConnectionInfo);
+
+        Task<ShellProfile> GetSshShellProfileAsync();
 
         string ConvertToUri(ISshConnectionInfo sshConnectionInfo);
     }

--- a/FluentTerminal.App.ViewModels/SshConnectionInfoViewModel.cs
+++ b/FluentTerminal.App.ViewModels/SshConnectionInfoViewModel.cs
@@ -78,6 +78,7 @@ namespace FluentTerminal.App.ViewModels
         public ObservableCollection<SshOptionViewModel> SshOptions { get; } =
             new ObservableCollection<SshOptionViewModel>();
 
+
         public SshConnectionInfoValidationResult Validate(bool allowNoUser = false)
         {
             if (!allowNoUser && string.IsNullOrEmpty(_username))
@@ -117,8 +118,13 @@ namespace FluentTerminal.App.ViewModels
         {
             SshConnectionInfoViewModel clone = new SshConnectionInfoViewModel
             {
-                _host = _host, _sshPort = _sshPort, _username = _username, _identityFile = _identityFile,
-                _useMosh = _useMosh, _moshPortFrom = _moshPortFrom, _moshPortTo = _moshPortTo,
+                _host = _host,
+                _sshPort = _sshPort,
+                _username = _username,
+                _identityFile = _identityFile,
+                _useMosh = _useMosh,
+                _moshPortFrom = _moshPortFrom,
+                _moshPortTo = _moshPortTo,
                 _lineEndingStyle = _lineEndingStyle
             };
 

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -208,14 +208,12 @@ namespace FluentTerminal.App
                         return;
                     }
 
-                    SshConnectionInfoValidationResult result = connectionInfo.Validate();
+                    var result = connectionInfo.Validate();
 
                     if (result != SshConnectionInfoValidationResult.Valid)
                     {
                         // Link is valid, but incomplete (i.e. username missing), so we need to show dialog.
-                        connectionInfo =
-                            (SshConnectionInfoViewModel)await _dialogService.ShowSshConnectionInfoDialogAsync(
-                                connectionInfo);
+                        connectionInfo = await _dialogService.ShowSshConnectionInfoDialogAsync(connectionInfo);
 
                         if (connectionInfo == null)
                         {
@@ -226,12 +224,16 @@ namespace FluentTerminal.App
                         }
                     }
 
-                    ShellProfile profile = _sshHelperService.CreateShellProfile(connectionInfo);
+                    var profile = _sshHelperService.CreateShellProfile(connectionInfo);
 
                     if (mainViewModel == null)
+                    {
                         await CreateTerminal(profile, _applicationSettings.NewTerminalLocation);
+                    }
                     else
+                    {
                         mainViewModel.AddTerminal(profile);
+                    }
 
                     return;
                 }

--- a/FluentTerminal.App/Services/SshHelperService.cs
+++ b/FluentTerminal.App/Services/SshHelperService.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
-using Windows.UI.Popups;
 using FluentTerminal.App.ViewModels;
 using FluentTerminal.Models;
 using FluentTerminal.Models.Enums;
@@ -56,104 +55,21 @@ namespace FluentTerminal.App.Services
             return Path.Combine(system32Folder, @"OpenSSH\ssh.exe");
         });
 
-        private static SshConnectionInfoViewModel ParseSsh(Uri uri)
-        {
-            SshConnectionInfoViewModel vm = new SshConnectionInfoViewModel
-            {
-                Host = uri.Host,
-                UseMosh = MoshUriScheme.Equals(uri.Scheme, StringComparison.OrdinalIgnoreCase)
-            };
-
-            if (uri.Port >= 0)
-            {
-                vm.SshPort = (ushort)uri.Port;
-            }
-
-            if (!string.IsNullOrEmpty(uri.UserInfo))
-            {
-                string[] parts = uri.UserInfo.Split(';');
-
-                if (parts.Length > 2)
-                {
-                    throw new FormatException($"UserInfo part contains {parts.Length} elements.");
-                }
-
-                vm.Username = HttpUtility.UrlDecode(parts[0]);
-
-                if (parts.Length > 1)
-                {
-                    LoadSshOptionsFromUri(vm, parts[1]);
-                }
-            }
-
-            if (string.IsNullOrEmpty(uri.Query))
-            {
-                return vm;
-            }
-
-            if (!vm.UseMosh)
-            {
-                throw new FormatException("Query parameters are not supported in SSH links.");
-            }
-
-            string queryString = uri.Query;
-
-            if (queryString.StartsWith("?", StringComparison.Ordinal))
-            {
-                queryString = queryString.Substring(1);
-            }
-
-            if (string.IsNullOrEmpty(queryString))
-            {
-                return vm;
-            }
-
-            foreach (SshOptionViewModel option in ParseSshOptionsFromUri(queryString, '&'))
-            {
-                if (ValidMoshPortsNames.Any(n => n.Equals(option.Name, StringComparison.OrdinalIgnoreCase)))
-                {
-                    Match match = MoshRangeRx.Match(option.Value);
-
-                    if (!match.Success)
-                    {
-                        throw new FormatException($"Invalid mosh ports range '{option.Value}'.");
-                    }
-
-                    vm.MoshPortFrom = ushort.Parse(match.Groups["from"].Value);
-                    vm.MoshPortTo = ushort.Parse(match.Groups["to"].Value);
-                }
-                else
-                {
-                    throw new FormatException($"Unknown query parameter '{option.Name}'.");
-                }
-            }
-
-            return vm;
-        }
-
         private static void LoadSshOptionsFromUri(SshConnectionInfoViewModel vm, string optsString)
         {
             vm.SshOptions.Clear();
 
             if (string.IsNullOrEmpty(optsString))
-            {
                 return;
-            }
 
             foreach (SshOptionViewModel option in ParseSshOptionsFromUri(optsString, ','))
             {
                 if (option.Name.Equals(IdentityFileOptionName, StringComparison.OrdinalIgnoreCase))
-                {
                     vm.IdentityFile = option.Value;
-                }
                 else if (vm.SshOptions.Any(opt => string.Equals(opt.Name, option.Name, StringComparison.OrdinalIgnoreCase)))
-                {
                     throw new FormatException($"SSH option '{option.Name}' is defined more than once.");
-                }
                 else
-                {
                     vm.SshOptions.Add(option);
-                }
             }
         }
 
@@ -165,9 +81,7 @@ namespace FluentTerminal.App.Services
             string[] nv = option.Split('=');
 
             if (nv.Length != 2 || string.IsNullOrEmpty(nv[0]))
-            {
                 throw new FormatException($"Invalid SSH option '{option}'.");
-            }
 
             return new SshOptionViewModel { Name = HttpUtility.UrlDecode(nv[0]), Value = HttpUtility.UrlDecode(nv[1]) };
         }
@@ -177,18 +91,14 @@ namespace FluentTerminal.App.Services
             string name = option.Name;
 
             if (string.IsNullOrEmpty(name))
-            {
                 throw new ArgumentException($"{nameof(SshOptionViewModel.Name)} must contain non empty string.");
-            }
 
             name = HttpUtility.UrlEncode(name);
 
             string value = option.Value;
 
             if (!string.IsNullOrEmpty(value))
-            {
                 value = HttpUtility.UrlEncode(value);
-            }
 
             return $"{name}={value}";
         }
@@ -198,38 +108,21 @@ namespace FluentTerminal.App.Services
             StringBuilder sb = new StringBuilder();
 
             if (sshConnectionInfo.SshPort != SshConnectionInfoViewModel.DefaultSshPort)
-            {
                 sb.Append($"-p {sshConnectionInfo.SshPort:#####} ");
-            }
 
             if (!string.IsNullOrEmpty(sshConnectionInfo.IdentityFile))
-            {
                 sb.Append($"-i \"{sshConnectionInfo.IdentityFile}\" ");
-            }
 
             foreach (SshOptionViewModel option in sshConnectionInfo.SshOptions)
-            {
                 sb.Append($"-o \"{option.Name}={option.Value}\" ");
-            }
 
             sb.Append($"{sshConnectionInfo.Username}@{sshConnectionInfo.Host}");
 
             if (sshConnectionInfo.UseMosh)
-            {
                 sb.Append($" {sshConnectionInfo.MoshPortFrom}:{sshConnectionInfo.MoshPortTo}");
-            }
 
             return sb.ToString();
         }
-
-        private static ShellProfile GetShellProfile(SshConnectionInfoViewModel sshConnectionInfo) =>
-            new ShellProfile
-            {
-                Arguments = GetArgumentsString(sshConnectionInfo),
-                Location = sshConnectionInfo.UseMosh ? MoshExe : SshExeLocationLazy.Value,
-                WorkingDirectory = string.Empty,
-                LineEndingTranslation = sshConnectionInfo.LineEndingStyle
-            };
 
         #endregion Static
 
@@ -251,60 +144,87 @@ namespace FluentTerminal.App.Services
             SshUriScheme.Equals(uri?.Scheme, StringComparison.OrdinalIgnoreCase) ||
             MoshUriScheme.Equals(uri?.Scheme, StringComparison.OrdinalIgnoreCase);
 
+        public ISshConnectionInfo ParseSsh(Uri uri)
+        {
+            SshConnectionInfoViewModel vm = new SshConnectionInfoViewModel
+            {
+                Host = uri.Host,
+                UseMosh = MoshUriScheme.Equals(uri.Scheme, StringComparison.OrdinalIgnoreCase)
+            };
+
+            if (uri.Port >= 0)
+                vm.SshPort = (ushort)uri.Port;
+
+            if (!string.IsNullOrEmpty(uri.UserInfo))
+            {
+                string[] parts = uri.UserInfo.Split(';');
+
+                if (parts.Length > 2)
+                    throw new FormatException($"UserInfo part contains {parts.Length} elements.");
+
+                vm.Username = HttpUtility.UrlDecode(parts[0]);
+
+                if (parts.Length > 1)
+                    LoadSshOptionsFromUri(vm, parts[1]);
+            }
+
+            if (string.IsNullOrEmpty(uri.Query))
+                return vm;
+
+            if (!vm.UseMosh)
+                throw new FormatException("Query parameters are not supported in SSH links.");
+
+            string queryString = uri.Query;
+
+            if (queryString.StartsWith("?", StringComparison.Ordinal))
+                queryString = queryString.Substring(1);
+
+            if (string.IsNullOrEmpty(queryString))
+                return vm;
+
+            foreach (SshOptionViewModel option in ParseSshOptionsFromUri(queryString, '&'))
+            {
+                if (ValidMoshPortsNames.Any(n => n.Equals(option.Name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    Match match = MoshRangeRx.Match(option.Value);
+
+                    if (!match.Success)
+                        throw new FormatException($"Invalid mosh ports range '{option.Value}'.");
+
+                    vm.MoshPortFrom = ushort.Parse(match.Groups["from"].Value);
+                    vm.MoshPortTo = ushort.Parse(match.Groups["to"].Value);
+                }
+                else
+                    throw new FormatException($"Unknown query parameter '{option.Name}'.");
+            }
+
+            return vm;
+        }
+
+        public ShellProfile CreateShellProfile(ISshConnectionInfo sshConnectionInfo) =>
+            new ShellProfile
+            {
+                Arguments = GetArgumentsString((SshConnectionInfoViewModel) sshConnectionInfo),
+                Location = sshConnectionInfo.UseMosh ? MoshExe : SshExeLocationLazy.Value,
+                WorkingDirectory = string.Empty,
+                LineEndingTranslation = sshConnectionInfo.LineEndingStyle
+            };
+
         public async Task<ShellProfile> GetSshShellProfileAsync()
         {
             SshConnectionInfoViewModel sshConnectionInfo =
                 (SshConnectionInfoViewModel) await _dialogService.ShowSshConnectionInfoDialogAsync();
 
             // sshConnectionInfo can be null if user clicks "Cancel".
-            return sshConnectionInfo == null ? null : GetShellProfile(sshConnectionInfo);
-        }
-
-        public async Task<ShellProfile> GetSshShellProfileAsync(Uri uri)
-        {
-            if (!IsSsh(uri))
-            {
-                throw new ArgumentException("Input argument is not a SSH URI.", nameof(uri));
-            }
-
-            SshConnectionInfoViewModel sshConnectionInfo;
-
-            try
-            {
-                sshConnectionInfo = ParseSsh(uri);
-            }
-            catch (Exception ex)
-            {
-                await new MessageDialog($"Invalid link: {ex.Message}", "Invalid Link").ShowAsync();
-
-                return null;
-            }
-
-            var validationResult = sshConnectionInfo.Validate();
-
-            if (validationResult != SshConnectionInfoValidationResult.Valid)
-            {
-                // Happens if the link doesn't contain all the needed data, so we have to prompt user to complete.
-                sshConnectionInfo = (SshConnectionInfoViewModel) await _dialogService.ShowSshConnectionInfoDialogAsync();
-
-                // sshConnectionInfo can be null if user clicks "Cancel".
-                if (sshConnectionInfo == null)
-                {
-                    return null;
-                }
-            }
-
-            return GetShellProfile(sshConnectionInfo);
+            return sshConnectionInfo == null ? null : CreateShellProfile(sshConnectionInfo);
         }
 
         public string ConvertToUri(ISshConnectionInfo sshConnectionInfo)
         {
-            var validationResult = sshConnectionInfo.Validate(true);
+            SshConnectionInfoValidationResult result = sshConnectionInfo.Validate(true);
 
-            if (validationResult != SshConnectionInfoValidationResult.Valid)
-            {
-                throw new ArgumentException(validationResult.ToString(), nameof(sshConnectionInfo));
-            }
+            if (result != SshConnectionInfoValidationResult.Valid)
+                throw new ArgumentException(result.ToString(), nameof(sshConnectionInfo));
 
             SshConnectionInfoViewModel sshConnectionInfoVm = (SshConnectionInfoViewModel) sshConnectionInfo;
 
@@ -337,9 +257,7 @@ namespace FluentTerminal.App.Services
                 foreach (string option in sshConnectionInfoVm.SshOptions.Select(ToUriOption))
                 {
                     if (!first)
-                    {
                         sb.Append(",");
-                    }
 
                     sb.Append(option);
 
@@ -350,9 +268,7 @@ namespace FluentTerminal.App.Services
             }
 
             if (containsUserInfo)
-            {
                 sb.Append("@");
-            }
 
             sb.Append(sshConnectionInfoVm.Host);
 


### PR DESCRIPTION
The key thing that I've needed to do is to ensure that the window is created before we have `ShellProfile`. So far we were creating the window only with `ShellProfile` ready. Now we need "SSH Info" dialog in order to create `ShellProfile`, and we need a window to be created in order to show "SSH Info" dialog...