### PR TITLE
Ignore multiple launch requests at the same time

### DIFF
--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -46,6 +46,7 @@ namespace FluentTerminal.App
         private readonly ISshHelperService _sshHelperService;
         private readonly IDialogService _dialogService;
         private bool _alreadyLaunched;
+        private bool _isLaunching = false;
         private ApplicationSettings _applicationSettings;
         private readonly IContainer _container;
         private readonly List<MainViewModel> _mainViewModels;
@@ -334,6 +335,10 @@ namespace FluentTerminal.App
 
         protected override async void OnLaunched(LaunchActivatedEventArgs args)
         {
+            if (_isLaunching)
+                return;
+
+            _isLaunching = true;
             if (!_alreadyLaunched)
             {
                 await InitializeLogger();
@@ -362,6 +367,7 @@ namespace FluentTerminal.App
                 var profile = _settingsService.GetShellProfile(Guid.Parse(args.Arguments.Replace(JumpListHelper.ShellProfileFlag, string.Empty)));
                 await CreateTerminal(profile, location).ConfigureAwait(true);
             }
+            _isLaunching = false;
         }
 
         private static async Task InitializeLogger()

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -46,7 +46,7 @@ namespace FluentTerminal.App
         private readonly ISshHelperService _sshHelperService;
         private readonly IDialogService _dialogService;
         private bool _alreadyLaunched;
-        private bool _isLaunching = false;
+        private bool _isLaunching;
         private ApplicationSettings _applicationSettings;
         private readonly IContainer _container;
         private readonly List<MainViewModel> _mainViewModels;
@@ -336,7 +336,9 @@ namespace FluentTerminal.App
         protected override async void OnLaunched(LaunchActivatedEventArgs args)
         {
             if (_isLaunching)
+            {
                 return;
+            }
 
             _isLaunching = true;
             if (!_alreadyLaunched)


### PR DESCRIPTION
PR to avoid crashes on multiple launch requests.

Crash repro steps:
- Launch powershell command line
- Quickly one by one execute multiple times following command to launch FT:

```
explorer.exe shell:AppsFolder\$(get-appxpackage -name 53621FSApps.FluentTerminal | select -expandproperty PackageFamilyName)!App
```

