### PR TITLE
Disable context menu for TextBox controls of SSH connection dialog

### DIFF
--- a/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
+++ b/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
@@ -7,6 +7,7 @@
     xmlns:vm="using:FluentTerminal.App.ViewModels"
     xmlns:controls="using:Microsoft.Toolkit.Uwp.UI.Controls"
     xmlns:enums="using:FluentTerminal.Models.Enums"
+    xmlns:utilities="using:FluentTerminal.App.Utilities"
     Title="SSH Info"
     x:Uid="SshInfoDialog"
     PrimaryButtonClick="SshInfoDialog_OnPrimaryButtonClick"
@@ -30,25 +31,25 @@
             <RowDefinition Height="Auto" />
             <RowDefinition />
         </Grid.RowDefinitions>
-        <TextBox x:Name="UserTextBox" Grid.Column="0" Grid.Row="0" x:Uid="UserTextBox"
+        <utilities:DisabledContextMenuTextBox x:Name="UserTextBox" Grid.Column="0" Grid.Row="0" x:Uid="UserTextBox"
                  PlaceholderText="user"
                  Text="{Binding Username, Mode=TwoWay}" />
         <TextBlock Grid.Column="1" Grid.Row="0"
                    FontSize="22"
                    Text="@" />
-        <TextBox x:Name="HostTextBox"  Grid.Column="2" Grid.Row="0" x:Uid="HostTextBox"
+        <utilities:DisabledContextMenuTextBox x:Name="HostTextBox"  Grid.Column="2" Grid.Row="0" x:Uid="HostTextBox"
                  PlaceholderText="host"
                  Text="{Binding Host, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
         <TextBlock Grid.Column="3" Grid.Row="0"
                    Margin="2 0 0 0"
                    FontSize="22"
                    Text=":" />
-        <TextBox Grid.Column="4" Grid.Row="0"
+        <utilities:DisabledContextMenuTextBox Grid.Column="4" Grid.Row="0"
                  Width="76"
                  x:Uid="PortTextBox"
                  PlaceholderText="port"
                  Text="{Binding SshPort, Mode=TwoWay}" BeforeTextChanging="Port_OnBeforeTextChanging"/>
-        <TextBox Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="3"
+        <utilities:DisabledContextMenuTextBox Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="3"
                  Text="{Binding IdentityFile, Mode=TwoWay}"
                  x:Uid="IdentityFileTextBox"
                  PlaceholderText="Identity file path"
@@ -104,7 +105,7 @@
                            Margin="0 8 8 0"
                            VerticalAlignment="Center"
                            Visibility="{Binding UseMosh}"/>
-                <TextBox Grid.Column="1" Grid.Row="1" 
+                <utilities:DisabledContextMenuTextBox Grid.Column="1" Grid.Row="1" 
                          Text="{Binding MoshPortFrom, Mode=TwoWay}" 
                          Margin="0 8 0 0"
                          BeforeTextChanging="Port_OnBeforeTextChanging"
@@ -115,7 +116,7 @@
                            Margin="2 8 0 0"
                            VerticalAlignment="Center"
                            Visibility="{Binding UseMosh}"/>
-                <TextBox Grid.Column="3" Grid.Row="1" 
+                <utilities:DisabledContextMenuTextBox Grid.Column="3" Grid.Row="1" 
                          Text="{Binding MoshPortTo, Mode=TwoWay}" 
                          BeforeTextChanging="Port_OnBeforeTextChanging"
                          Margin="0 8 0 0"

--- a/FluentTerminal.App/FluentTerminal.App.csproj
+++ b/FluentTerminal.App/FluentTerminal.App.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Utilities\ColorExtensions.cs" />
     <Compile Include="Utilities\ContrastHelper.cs" />
     <Compile Include="Utilities\DebouncedAction.cs" />
+    <Compile Include="Utilities\DisabledContextMenuTextBox.cs" />
     <Compile Include="Utilities\JumpListHelper.cs" />
     <Compile Include="Views\BooleanTemplateSelector.cs" />
     <Compile Include="Views\KeyBindingsView.xaml.cs">

--- a/FluentTerminal.App/Utilities/DisabledContextMenuTextBox.cs
+++ b/FluentTerminal.App/Utilities/DisabledContextMenuTextBox.cs
@@ -1,0 +1,17 @@
+﻿using Windows.UI.Xaml.Controls;
+
+namespace FluentTerminal.App.Utilities
+{
+    public sealed class DisabledContextMenuTextBox : TextBox
+    {
+        public DisabledContextMenuTextBox() : base()
+        {
+            ContextMenuOpening += OnContextMenuOpening;
+        }
+
+        private void OnContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            e.Handled = true;
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/jumptrading/FluentTerminal/issues/86

Workaround to disable non-customizable default context menu for TextBox control.