### PR TITLE
Improve IPC

### DIFF
--- a/FluentTerminal.App.Services.Test/FluentTerminal.App.Services.Test.csproj
+++ b/FluentTerminal.App.Services.Test/FluentTerminal.App.Services.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -32,6 +32,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FluentTerminal.App.Services\FluentTerminal.App.Services.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Windows.Foundation.FoundationContract">
+      <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\References\10.0.16299.0\Windows.Foundation.FoundationContract\3.0.0.0\Windows.Foundation.FoundationContract.winmd</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/FluentTerminal.App.Services.Test/TrayProcessCommunicationServiceTests.cs
+++ b/FluentTerminal.App.Services.Test/TrayProcessCommunicationServiceTests.cs
@@ -44,7 +44,7 @@ namespace FluentTerminal.App.Services.Test
             var terminalSize = _fixture.Create<TerminalSize>();
             var shellProfile = _fixture.Create<ShellProfile>();
             var sessionType = _fixture.Create<SessionType>();
-            var id = _fixture.Create<int>();
+            var id = _fixture.Create<byte>();
             var trayProcessCommunicationService = new TrayProcessCommunicationService(settingsService.Object);
             trayProcessCommunicationService.Initialize(appServiceConnection.Object);
 
@@ -56,7 +56,7 @@ namespace FluentTerminal.App.Services.Test
         [Fact]
         public async Task ResizeTerminal_Default_SendsResizeTerminalRequest()
         {
-            var terminalId = _fixture.Create<int>();
+            var terminalId = _fixture.Create<byte>();
             var terminalSize = _fixture.Create<TerminalSize>();
             var settingsService = new Mock<ISettingsService>();
             var keyBindings = _fixture.CreateMany<KeyBinding>(3);
@@ -76,7 +76,7 @@ namespace FluentTerminal.App.Services.Test
         [Fact]
         public async Task Write_Default_SendsWriteDataRequest()
         {
-            var terminalId = _fixture.Create<int>();
+            var terminalId = _fixture.Create<byte>();
             var data = _fixture.Create<byte[]>();
             var settingsService = new Mock<ISettingsService>();
             var keyBindings = _fixture.CreateMany<KeyBinding>(3);
@@ -96,7 +96,7 @@ namespace FluentTerminal.App.Services.Test
         [Fact]
         public async Task CloseTerminal_Default_SendsTerminalExitedRequest()
         {
-            var terminalId = _fixture.Create<int>();
+            var terminalId = _fixture.Create<byte>();
             var settingsService = new Mock<ISettingsService>();
             var keyBindings = _fixture.CreateMany<KeyBinding>(3);
             settingsService.Setup(x => x.GetCommandKeyBindings()).Returns(new Dictionary<string, ICollection<KeyBinding>>
@@ -115,7 +115,7 @@ namespace FluentTerminal.App.Services.Test
         [Fact]
         public void OnMessageReceived_TerminalExitedRequest_InvokesTerminalExitedEvent()
         {
-            var request = new TerminalExitedRequest(_fixture.Create<int>(), _fixture.Create<int>());
+            var request = new TerminalExitedRequest(_fixture.Create<byte>(), _fixture.Create<int>());
 
             var receivedExitStatus = (TerminalExitStatus) null;
 
@@ -148,7 +148,7 @@ namespace FluentTerminal.App.Services.Test
         [Fact]
         public void OnMessageReceived_DisplayTerminalOutputRequest_InvokesCorrectOutputHandler()
         {
-            var terminalId = _fixture.Create<int>();
+            var terminalId = _fixture.Create<byte>();
             var output = _fixture.Create<byte[]>();
             var receivedOutput = default(byte[]);
             var message = new ValueSet

--- a/FluentTerminal.App.Services/Constants.cs
+++ b/FluentTerminal.App.Services/Constants.cs
@@ -5,5 +5,7 @@
         public const string ThemesContainerName = "Themes";
         public const string KeyBindingsContainerName = "KeyBindings";
         public const string ShellProfilesContainerName = "ShellProfiles";
+
+        public const byte TerminalBufferRequestIdentifier = 0;
     }
 }

--- a/FluentTerminal.App.Services/IAppServiceConnection.cs
+++ b/FluentTerminal.App.Services/IAppServiceConnection.cs
@@ -1,13 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
+using Windows.Foundation.Collections;
 
 namespace FluentTerminal.App.Services
 {
     public interface IAppServiceConnection
     {
-        event EventHandler<IDictionary<string, string>> MessageReceived;
+        event EventHandler<ValueSet> MessageReceived;
 
-        Task<IDictionary<string, string>> SendMessageAsync(IDictionary<string, string> message);
+        Task<ValueSet> SendMessageAsync(ValueSet message);
     }
 }

--- a/FluentTerminal.App.Services/ITrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/ITrayProcessCommunicationService.cs
@@ -12,19 +12,19 @@ namespace FluentTerminal.App.Services
 
         void Initialize(IAppServiceConnection appServiceConnection);
 
-        Task<CreateTerminalResponse> CreateTerminal(int id, TerminalSize size, ShellProfile shellProfile, SessionType sessionType);
+        Task<CreateTerminalResponse> CreateTerminal(byte id, TerminalSize size, ShellProfile shellProfile, SessionType sessionType);
 
-        Task ResizeTerminal(int id, TerminalSize size);
+        Task ResizeTerminal(byte id, TerminalSize size);
 
         Task UpdateToggleWindowKeyBindings();
 
-        Task Write(int terminalId, byte[] data);
+        Task Write(byte terminalId, byte[] data);
 
-        void SubscribeForTerminalOutput(int terminalId, Action<byte[]> callback);
+        void SubscribeForTerminalOutput(byte terminalId, Action<byte[]> callback);
 
-        Task CloseTerminal(int terminalId);
+        Task CloseTerminal(byte terminalId);
         Task<GetAvailablePortResponse> GetAvailablePort();
-        int GetNextTerminalId();
+        byte GetNextTerminalId();
 
         Task<string> GetUserName();
 

--- a/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
@@ -14,18 +14,18 @@ namespace FluentTerminal.App.Services.Implementation
     {
         private readonly ISettingsService _settingsService;
         private IAppServiceConnection _appServiceConnection;
-        private readonly Dictionary<int, Action<byte[]>> _terminalOutputHandlers;
-        private int _nextTerminalId = 0;
+        private readonly Dictionary<byte, Action<byte[]>> _terminalOutputHandlers;
+        private byte _nextTerminalId = 0;
 
         public event EventHandler<TerminalExitStatus> TerminalExited;
 
         public TrayProcessCommunicationService(ISettingsService settingsService)
         {
             _settingsService = settingsService;
-            _terminalOutputHandlers = new Dictionary<int, Action<byte[]>>();
+            _terminalOutputHandlers = new Dictionary<byte, Action<byte[]>>();
         }
 
-        public int GetNextTerminalId()
+        public byte GetNextTerminalId()
         {
             return _nextTerminalId++;
         }
@@ -86,7 +86,7 @@ namespace FluentTerminal.App.Services.Implementation
             }
         }
 
-        public async Task<CreateTerminalResponse> CreateTerminal(int id, TerminalSize size, ShellProfile shellProfile, SessionType sessionType)
+        public async Task<CreateTerminalResponse> CreateTerminal(byte id, TerminalSize size, ShellProfile shellProfile, SessionType sessionType)
         {
             var request = new CreateTerminalRequest
             {
@@ -120,7 +120,7 @@ namespace FluentTerminal.App.Services.Implementation
             switch (messageType)
             {
                 case Constants.TerminalBufferRequestIdentifier:
-                    var terminalId = (int)e[MessageKeys.TerminalId];
+                    var terminalId = (byte)e[MessageKeys.TerminalId];
 
                     if (_terminalOutputHandlers.ContainsKey(terminalId))
                     {
@@ -143,7 +143,7 @@ namespace FluentTerminal.App.Services.Implementation
             }
         }
 
-        public Task ResizeTerminal(int id, TerminalSize size)
+        public Task ResizeTerminal(byte id, TerminalSize size)
         {
             var request = new ResizeTerminalRequest
             {
@@ -154,7 +154,7 @@ namespace FluentTerminal.App.Services.Implementation
             return _appServiceConnection.SendMessageAsync(CreateMessage(request));
         }
 
-        public void SubscribeForTerminalOutput(int terminalId, Action<byte[]> callback)
+        public void SubscribeForTerminalOutput(byte terminalId, Action<byte[]> callback)
         {
             _terminalOutputHandlers[terminalId] = callback;
         }
@@ -171,7 +171,7 @@ namespace FluentTerminal.App.Services.Implementation
             return _appServiceConnection.SendMessageAsync(CreateMessage(request));
         }
 
-        public Task Write(int id, byte[] data)
+        public Task Write(byte id, byte[] data)
         {
             var message = new ValueSet
             {
@@ -183,7 +183,7 @@ namespace FluentTerminal.App.Services.Implementation
             return _appServiceConnection.SendMessageAsync(message);
         }
 
-        public Task CloseTerminal(int terminalId)
+        public Task CloseTerminal(byte terminalId)
         {
             var request = new TerminalExitedRequest(terminalId, -1);
 

--- a/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Windows.Foundation.Collections;
 
 namespace FluentTerminal.App.Services.Implementation
 {
@@ -34,7 +35,7 @@ namespace FluentTerminal.App.Services.Implementation
             var request = new GetAvailablePortRequest();
 
             var responseMessage = await _appServiceConnection.SendMessageAsync(CreateMessage(request));
-            var response = JsonConvert.DeserializeObject<GetAvailablePortResponse>(responseMessage[MessageKeys.Content]);
+            var response = JsonConvert.DeserializeObject<GetAvailablePortResponse>((string)responseMessage[MessageKeys.Content]);
 
             Logger.Instance.Debug("Received GetAvailablePortResponse: {@response}", response);
 
@@ -57,7 +58,7 @@ namespace FluentTerminal.App.Services.Implementation
             try
             {
                 var responseMessage = await _appServiceConnection.SendMessageAsync(CreateMessage(new GetUserNameRequest()));
-                response = JsonConvert.DeserializeObject<GetUserNameResponse>(responseMessage[MessageKeys.Content]);
+                response = JsonConvert.DeserializeObject<GetUserNameResponse>((string)responseMessage[MessageKeys.Content]);
             }
             catch (Exception e)
             {
@@ -75,12 +76,9 @@ namespace FluentTerminal.App.Services.Implementation
 
         public async Task SaveTextFileAsync(string path, string content)
         {
-            IDictionary<string, string> responseMessage =
-                await _appServiceConnection.SendMessageAsync(CreateMessage(new SaveTextFileRequest
-                    {Path = path, Content = content}));
+            var responseMessage = await _appServiceConnection.SendMessageAsync(CreateMessage(new SaveTextFileRequest {Path = path, Content = content}));
 
-            CommonResponse response =
-                JsonConvert.DeserializeObject<CommonResponse>(responseMessage[MessageKeys.Content]);
+            var response = JsonConvert.DeserializeObject<CommonResponse>((string)responseMessage[MessageKeys.Content]);
 
             if (!response.Success)
             {
@@ -101,7 +99,7 @@ namespace FluentTerminal.App.Services.Implementation
             Logger.Instance.Debug("Sending CreateTerminalRequest: {@request}", request);
 
             var responseMessage = await _appServiceConnection.SendMessageAsync(CreateMessage(request));
-            var response = JsonConvert.DeserializeObject<CreateTerminalResponse>(responseMessage[MessageKeys.Content]);
+            var response = JsonConvert.DeserializeObject<CreateTerminalResponse>((string)responseMessage[MessageKeys.Content]);
 
             Logger.Instance.Debug("Received CreateTerminalResponse: {@response}", response);
 
@@ -114,30 +112,34 @@ namespace FluentTerminal.App.Services.Implementation
             _appServiceConnection.MessageReceived += OnMessageReceived;
         }
 
-        private void OnMessageReceived(object sender, IDictionary<string, string> e)
+        private void OnMessageReceived(object sender, IDictionary<string, object> e)
         {
-            var messageType = e[MessageKeys.Type];
+            var messageType = (byte)e[MessageKeys.Type];
             var messageContent = e[MessageKeys.Content];
 
-            if (messageType == nameof(DisplayTerminalOutputRequest))
+            switch (messageType)
             {
-                var request = JsonConvert.DeserializeObject<DisplayTerminalOutputRequest>(messageContent);
+                case Constants.TerminalBufferRequestIdentifier:
+                    var terminalId = (int)e[MessageKeys.TerminalId];
 
-                if (_terminalOutputHandlers.ContainsKey(request.TerminalId))
-                {
-                    _terminalOutputHandlers[request.TerminalId].Invoke(request.Output);
-                }
-                else
-                {
-                    Logger.Instance.Error("Received output for unknown terminal Id {id}", request.TerminalId);
-                }
-            }
-            else if (messageType == nameof(TerminalExitedRequest))
-            {
-                var request = JsonConvert.DeserializeObject<TerminalExitedRequest>(messageContent);
-                Logger.Instance.Debug("Received TerminalExitedRequest: {@request}", request);
+                    if (_terminalOutputHandlers.ContainsKey(terminalId))
+                    {
+                        _terminalOutputHandlers[terminalId].Invoke((byte[])messageContent);
+                    }
+                    else
+                    {
+                        Logger.Instance.Error("Received output for unknown terminal Id {id}", terminalId);
+                    }
+                    break;
+                case TerminalExitedRequest.Identifier:
+                    var request = JsonConvert.DeserializeObject<TerminalExitedRequest>((string)messageContent);
+                    Logger.Instance.Debug("Received TerminalExitedRequest: {@request}", request);
 
-                TerminalExited?.Invoke(this, request.ToStatus());
+                    TerminalExited?.Invoke(this, request.ToStatus());
+                    break;
+                default:
+                    Logger.Instance.Error("Received unknown message type: {messageType}", messageType);
+                    break;
             }
         }
 
@@ -171,13 +173,14 @@ namespace FluentTerminal.App.Services.Implementation
 
         public Task Write(int id, byte[] data)
         {
-            var request = new WriteDataRequest
+            var message = new ValueSet
             {
-                TerminalId = id,
-                Data = data
+                [MessageKeys.Type] = Constants.TerminalBufferRequestIdentifier,
+                [MessageKeys.TerminalId] = id,
+                [MessageKeys.Content] = data
             };
 
-            return _appServiceConnection.SendMessageAsync(CreateMessage(request));
+            return _appServiceConnection.SendMessageAsync(message);
         }
 
         public Task CloseTerminal(int terminalId)
@@ -189,11 +192,11 @@ namespace FluentTerminal.App.Services.Implementation
             return _appServiceConnection.SendMessageAsync(CreateMessage(request));
         }
 
-        private IDictionary<string, string> CreateMessage(object content)
+        private ValueSet CreateMessage(IMessage content)
         {
-            return new Dictionary<string, string>
+            return new ValueSet
             {
-                [MessageKeys.Type] = content.GetType().Name,
+                [MessageKeys.Type] = content.Identifier,
                 [MessageKeys.Content] = JsonConvert.SerializeObject(content)
             };
         }

--- a/FluentTerminal.App.Services/Terminal.cs
+++ b/FluentTerminal.App.Services/Terminal.cs
@@ -65,7 +65,7 @@ namespace FluentTerminal.App.Services
 
         public string FallbackTitle { get; private set; }
 
-        public int Id { get; }
+        public byte Id { get; }
 
         /// <summary>
         /// To be called by either view or viewmodel

--- a/FluentTerminal.App/Adapters/AppServiceConnectionAdapter.cs
+++ b/FluentTerminal.App/Adapters/AppServiceConnectionAdapter.cs
@@ -12,7 +12,7 @@ namespace FluentTerminal.App.Adapters
     {
         private readonly AppServiceConnection _appServiceConnection;
 
-        public event EventHandler<IDictionary<string, string>> MessageReceived;
+        public event EventHandler<ValueSet> MessageReceived;
 
         public AppServiceConnectionAdapter(AppServiceConnection appServiceConnection)
         {
@@ -22,35 +22,16 @@ namespace FluentTerminal.App.Adapters
 
         private void OnRequestReceived(AppServiceConnection sender, AppServiceRequestReceivedEventArgs args)
         {
-            var messageType = (string)args.Request.Message[MessageKeys.Type];
-            var messageContent = (string)args.Request.Message[MessageKeys.Content];
-
-            MessageReceived?.Invoke(this, new Dictionary<string, string>
-            {
-                [MessageKeys.Type] = messageType,
-                [MessageKeys.Content] = messageContent
-            });
+            MessageReceived?.Invoke(this, args.Request.Message);
         }
 
-        public async Task<IDictionary<string, string>> SendMessageAsync(IDictionary<string, string> message)
+        public async Task<ValueSet> SendMessageAsync(ValueSet message)
         {
-            var valueSet = new ValueSet();
-
-            foreach (var pair in message)
-            {
-                valueSet.Add(pair.Key, pair.Value);
-            }
-
-            var response = await _appServiceConnection.SendMessageAsync(valueSet).AsTask();
+            var response = await _appServiceConnection.SendMessageAsync(message).AsTask();
 
             if (response.Status == AppServiceResponseStatus.Success)
             {
-                var responseDict = new Dictionary<string, string>();
-                foreach (var pair in response.Message)
-                {
-                    responseDict.Add(pair.Key, (string)pair.Value);
-                }
-                return responseDict;
+                return response.Message;
             }
             return null;
         }

--- a/FluentTerminal.Models/IMessage.cs
+++ b/FluentTerminal.Models/IMessage.cs
@@ -1,0 +1,7 @@
+﻿namespace FluentTerminal.Models
+{
+    public interface IMessage
+    {
+        byte Identifier { get; }
+    }
+}

--- a/FluentTerminal.Models/MessageKeys.cs
+++ b/FluentTerminal.Models/MessageKeys.cs
@@ -2,8 +2,10 @@
 {
     public static class MessageKeys
     {
-        public static string Type => nameof(Type);
+        public static string Type => "T";
 
-        public static string Content => nameof(Content);
+        public static string Content => "C";
+
+        public static string TerminalId => "I";
     }
 }

--- a/FluentTerminal.Models/Requests/CreateTerminalRequest.cs
+++ b/FluentTerminal.Models/Requests/CreateTerminalRequest.cs
@@ -2,8 +2,12 @@
 
 namespace FluentTerminal.Models.Requests
 {
-    public class CreateTerminalRequest
+    public class CreateTerminalRequest : IMessage
     {
+        public const byte Identifier = 1;
+
+        byte IMessage.Identifier => Identifier;
+
         public int Id { get; set; }
         public TerminalSize Size { get; set; }
         public ShellProfile Profile { get; set; }

--- a/FluentTerminal.Models/Requests/CreateTerminalRequest.cs
+++ b/FluentTerminal.Models/Requests/CreateTerminalRequest.cs
@@ -8,7 +8,7 @@ namespace FluentTerminal.Models.Requests
 
         byte IMessage.Identifier => Identifier;
 
-        public int Id { get; set; }
+        public byte Id { get; set; }
         public TerminalSize Size { get; set; }
         public ShellProfile Profile { get; set; }
         public SessionType SessionType { get; set; }

--- a/FluentTerminal.Models/Requests/DisplayTerminalOutputRequest.cs
+++ b/FluentTerminal.Models/Requests/DisplayTerminalOutputRequest.cs
@@ -1,8 +1,0 @@
-﻿namespace FluentTerminal.Models.Requests
-{
-    public class DisplayTerminalOutputRequest
-    {
-        public int TerminalId { get; set; }
-        public byte[] Output { get; set; }
-    }
-}

--- a/FluentTerminal.Models/Requests/GetAvailablePortRequest.cs
+++ b/FluentTerminal.Models/Requests/GetAvailablePortRequest.cs
@@ -1,6 +1,9 @@
 ﻿namespace FluentTerminal.Models.Requests
 {
-    public class GetAvailablePortRequest
+    public class GetAvailablePortRequest : IMessage
     {
+        public const byte Identifier = 2;
+
+        byte IMessage.Identifier => Identifier;
     }
 }

--- a/FluentTerminal.Models/Requests/GetUserNameRequest.cs
+++ b/FluentTerminal.Models/Requests/GetUserNameRequest.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace FluentTerminal.Models.Requests
+﻿namespace FluentTerminal.Models.Requests
 {
-    public class GetUserNameRequest
+    public class GetUserNameRequest : IMessage
     {
+        public const byte Identifier = 3;
+
+        byte IMessage.Identifier => Identifier;
     }
 }

--- a/FluentTerminal.Models/Requests/ResizeTerminalRequest.cs
+++ b/FluentTerminal.Models/Requests/ResizeTerminalRequest.cs
@@ -6,7 +6,7 @@
 
         byte IMessage.Identifier => Identifier;
 
-        public int TerminalId { get; set; }
+        public byte TerminalId { get; set; }
 
         public TerminalSize NewSize { get; set; }
     }

--- a/FluentTerminal.Models/Requests/ResizeTerminalRequest.cs
+++ b/FluentTerminal.Models/Requests/ResizeTerminalRequest.cs
@@ -1,7 +1,11 @@
 ﻿namespace FluentTerminal.Models.Requests
 {
-    public class ResizeTerminalRequest
+    public class ResizeTerminalRequest : IMessage
     {
+        public const byte Identifier = 4;
+
+        byte IMessage.Identifier => Identifier;
+
         public int TerminalId { get; set; }
 
         public TerminalSize NewSize { get; set; }

--- a/FluentTerminal.Models/Requests/SaveTextFileRequest.cs
+++ b/FluentTerminal.Models/Requests/SaveTextFileRequest.cs
@@ -1,7 +1,11 @@
 ﻿namespace FluentTerminal.Models.Requests
 {
-    public class SaveTextFileRequest
+    public class SaveTextFileRequest : IMessage
     {
+        public const byte Identifier = 5;
+
+        byte IMessage.Identifier => Identifier;
+
         public string Path { get; set; }
 
         public string Content { get; set; }

--- a/FluentTerminal.Models/Requests/SetToggleWindowKeyBindingsRequest.cs
+++ b/FluentTerminal.Models/Requests/SetToggleWindowKeyBindingsRequest.cs
@@ -2,8 +2,12 @@
 
 namespace FluentTerminal.Models.Requests
 {
-    public class SetToggleWindowKeyBindingsRequest
+    public class SetToggleWindowKeyBindingsRequest : IMessage
     {
+        public const byte Identifier = 6;
+
+        byte IMessage.Identifier => Identifier;
+
         public IEnumerable<KeyBinding> KeyBindings { get; set; }
     }
 }

--- a/FluentTerminal.Models/Requests/TerminalExitedRequest.cs
+++ b/FluentTerminal.Models/Requests/TerminalExitedRequest.cs
@@ -6,36 +6,31 @@
 
         byte IMessage.Identifier => Identifier;
 
-        public int TerminalId { get; set; }
+        public byte TerminalId { get; set; }
         public int ExitCode { get; set; }
 
-        public TerminalExitedRequest(int terminalId, int exitCode)
+        public TerminalExitedRequest(byte terminalId, int exitCode)
         {
             TerminalId = terminalId;
             ExitCode = exitCode;
         }
 
-        public TerminalExitedRequest(int terminalId)
+        public TerminalExitedRequest(byte terminalId)
         {
             TerminalId = terminalId;
             ExitCode = -1;
         }
 
-        // This is for JSON deserialisation.
         public TerminalExitedRequest()
         {
-            TerminalId = -1;
-            ExitCode = -2;
         }
 
-        // Create a TerminalExitedRequest from a TerminalExitStatus.
         public TerminalExitedRequest(TerminalExitStatus status)
         {
             TerminalId = status.TerminalId;
             ExitCode = status.ExitCode;
         }
 
-        // Convert to a TerminalExitStatus.
         public TerminalExitStatus ToStatus()
         {
             return new TerminalExitStatus(TerminalId, ExitCode);

--- a/FluentTerminal.Models/Requests/TerminalExitedRequest.cs
+++ b/FluentTerminal.Models/Requests/TerminalExitedRequest.cs
@@ -1,6 +1,10 @@
 ﻿namespace FluentTerminal.Models.Requests
 {
-    public class TerminalExitedRequest {
+    public class TerminalExitedRequest : IMessage
+    {
+        public const byte Identifier = 7;
+
+        byte IMessage.Identifier => Identifier;
 
         public int TerminalId { get; set; }
         public int ExitCode { get; set; }

--- a/FluentTerminal.Models/Responses/CommonResponse.cs
+++ b/FluentTerminal.Models/Responses/CommonResponse.cs
@@ -1,7 +1,11 @@
 ﻿namespace FluentTerminal.Models.Responses
 {
-    public class CommonResponse
+    public class CommonResponse : IMessage
     {
+        public const byte Identifier = 8;
+
+        byte IMessage.Identifier => Identifier;
+
         public bool Success { get; set; }
 
         public string Error { get; set; }

--- a/FluentTerminal.Models/Responses/CreateTerminalResponse.cs
+++ b/FluentTerminal.Models/Responses/CreateTerminalResponse.cs
@@ -1,7 +1,11 @@
 ﻿namespace FluentTerminal.Models.Responses
 {
-    public class CreateTerminalResponse
+    public class CreateTerminalResponse :IMessage
     {
+        public const byte Identifier = 9;
+
+        byte IMessage.Identifier => Identifier;
+
         public bool Success { get; set; }
         public string Error { get; set; }
         public string ShellExecutableName { get; set; }

--- a/FluentTerminal.Models/Responses/GetAvailablePortResponse.cs
+++ b/FluentTerminal.Models/Responses/GetAvailablePortResponse.cs
@@ -1,7 +1,11 @@
 ﻿namespace FluentTerminal.Models.Responses
 {
-    public class GetAvailablePortResponse
+    public class GetAvailablePortResponse : IMessage
     {
+        public const byte Identifier = 10;
+
+        byte IMessage.Identifier => Identifier;
+
         public int Port { get; set; }
     }
 }

--- a/FluentTerminal.Models/Responses/GetUserNameResponse.cs
+++ b/FluentTerminal.Models/Responses/GetUserNameResponse.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace FluentTerminal.Models.Responses
+﻿namespace FluentTerminal.Models.Responses
 {
-    public class GetUserNameResponse
+    public class GetUserNameResponse : IMessage
     {
+        public const byte Identifier = 11;
+
+        byte IMessage.Identifier => Identifier;
+
         public string UserName { get; set; }
     }
 }

--- a/FluentTerminal.Models/TerminalExitStatus.cs
+++ b/FluentTerminal.Models/TerminalExitStatus.cs
@@ -1,18 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace FluentTerminal.Models
+﻿namespace FluentTerminal.Models
 {
     public class TerminalExitStatus
     {
-        public TerminalExitStatus(int terminalId, int exitCode)
+        public TerminalExitStatus(byte terminalId, int exitCode)
         {
             TerminalId = terminalId;
             ExitCode = exitCode;
         }
 
-        public int TerminalId { get; set; }
+        public byte TerminalId { get; set; }
         public int ExitCode { get; set; }
     }
 }

--- a/FluentTerminal.Models/TerminalOutput.cs
+++ b/FluentTerminal.Models/TerminalOutput.cs
@@ -2,7 +2,7 @@
 {
     public class TerminalOutput
     {
-        public int TerminalId { get; set; }
+        public byte TerminalId { get; set; }
         public byte[] Data { get; set; }
     }
 }

--- a/FluentTerminal.Models/TerminalOutput.cs
+++ b/FluentTerminal.Models/TerminalOutput.cs
@@ -1,9 +1,8 @@
-﻿namespace FluentTerminal.Models.Requests
+﻿namespace FluentTerminal.Models
 {
-    public class WriteDataRequest
+    public class TerminalOutput
     {
         public int TerminalId { get; set; }
-
         public byte[] Data { get; set; }
     }
 }

--- a/FluentTerminal.SystemTray/Services/AppCommunicationService.cs
+++ b/FluentTerminal.SystemTray/Services/AppCommunicationService.cs
@@ -117,7 +117,7 @@ namespace FluentTerminal.SystemTray.Services
 
         private void HandleWriteDataMessage(AppServiceRequestReceivedEventArgs args)
         {
-            var terminalId = (int)args.Request.Message[MessageKeys.TerminalId];
+            var terminalId = (byte)args.Request.Message[MessageKeys.TerminalId];
             var content = (byte[])args.Request.Message[MessageKeys.Content];
             _terminalsManager.Write(terminalId, content);
         }

--- a/FluentTerminal.SystemTray/Services/AppCommunicationService.cs
+++ b/FluentTerminal.SystemTray/Services/AppCommunicationService.cs
@@ -18,7 +18,8 @@ namespace FluentTerminal.SystemTray.Services
         private readonly TerminalsManager _terminalsManager;
         private readonly ToggleWindowService _toggleWindowService;
 
-        public static string EventWaitHandleName => "FluentTerminalNewInstanceEvent";
+        public const string EventWaitHandleName = "FluentTerminalNewInstanceEvent";
+        public const byte WriteDataMessageIdentifier = 0;
 
         public AppCommunicationService(TerminalsManager terminalsManager, ToggleWindowService toggleWindowService)
         {
@@ -45,9 +46,16 @@ namespace FluentTerminal.SystemTray.Services
             _appServiceConnection?.SendMessageAsync(CreateMessage(request));
         }
 
-        private void _terminalsManager_DisplayOutputRequested(object sender, DisplayTerminalOutputRequest e)
+        private void _terminalsManager_DisplayOutputRequested(object sender, TerminalOutput e)
         {
-            _appServiceConnection.SendMessageAsync(CreateMessage(e));
+            var message = new ValueSet
+            {
+                [MessageKeys.Type] = Constants.TerminalBufferRequestIdentifier,
+                [MessageKeys.TerminalId] = e.TerminalId,
+                [MessageKeys.Content] = e.Data
+            };
+
+            _appServiceConnection.SendMessageAsync(message);
         }
 
         public void StartAppServiceConnection()
@@ -73,98 +81,122 @@ namespace FluentTerminal.SystemTray.Services
 
         private async void OnRequestReceived(AppServiceConnection sender, AppServiceRequestReceivedEventArgs args)
         {
-            var messageType = (string)args.Request.Message[MessageKeys.Type];
-            var messageContent = (string)args.Request.Message[MessageKeys.Content];
+            var messageType = (byte)args.Request.Message[MessageKeys.Type];
 
-            if (messageType == nameof(CreateTerminalRequest))
+            switch (messageType)
             {
-                var deferral = args.GetDeferral();
-
-                var request = JsonConvert.DeserializeObject<CreateTerminalRequest>(messageContent);
-
-                Logger.Instance.Debug("Received CreateTerminalRequest: {@request}", request);
-
-                var response = _terminalsManager.CreateTerminal(request);
-
-                Logger.Instance.Debug("Sending CreateTerminalResponse: {@response}", response);
-
-                await args.Request.SendResponseAsync(CreateMessage(response));
-
-                deferral.Complete();
-            }
-            else if (messageType == nameof(ResizeTerminalRequest))
-            {
-                var request = JsonConvert.DeserializeObject<ResizeTerminalRequest>(messageContent);
-
-                _terminalsManager.ResizeTerminal(request.TerminalId, request.NewSize);
-            }
-            else if (messageType == nameof(SetToggleWindowKeyBindingsRequest))
-            {
-                var request = JsonConvert.DeserializeObject<SetToggleWindowKeyBindingsRequest>(messageContent);
-
-                _toggleWindowService.SetHotKeys(request.KeyBindings);
-            }
-            else if (messageType == nameof(WriteDataRequest))
-            {
-                var request = JsonConvert.DeserializeObject<WriteDataRequest>(messageContent);
-                _terminalsManager.Write(request.TerminalId, request.Data);
-            }
-            else if (messageType == nameof(TerminalExitedRequest))
-            {
-                var request = JsonConvert.DeserializeObject<TerminalExitedRequest>(messageContent);
-                _terminalsManager.CloseTerminal(request.TerminalId);
-            }
-            else if (messageType == nameof(GetAvailablePortRequest))
-            {
-                var deferral = args.GetDeferral();
-
-                var response = new GetAvailablePortResponse { Port = Utilities.GetAvailablePort().Value };
-
-                await args.Request.SendResponseAsync(CreateMessage(response));
-
-                deferral.Complete();
-            }
-            else if (messageType == nameof(GetUserNameRequest))
-            {
-                var deferral = args.GetDeferral();
-
-                var response = new GetUserNameResponse { UserName = Environment.UserName };
-
-                await args.Request.SendResponseAsync(CreateMessage(response));
-
-                deferral.Complete();
-            }
-            else if (messageType == nameof(SaveTextFileRequest))
-            {
-                var deferral = args.GetDeferral();
-
-                SaveTextFileRequest request = JsonConvert.DeserializeObject<SaveTextFileRequest>(messageContent);
-
-                CommonResponse response = new CommonResponse();
-
-                try
-                {
-                    Utilities.SaveFile(request.Path, request.Content);
-
-                    response.Success = true;
-                }
-                catch (Exception e)
-                {
-                    response.Success = false;
-                    response.Error = e.Message;
-                }
-
-                await args.Request.SendResponseAsync(CreateMessage(response));
-
-                deferral.Complete();
+                case WriteDataMessageIdentifier:
+                    HandleWriteDataMessage(args);
+                    break;
+                case CreateTerminalRequest.Identifier:
+                    await HandleCreateTerminalRequest(args);
+                    break;
+                case ResizeTerminalRequest.Identifier:
+                    HandleResizeTerminalRequest(args);
+                    break;
+                case SetToggleWindowKeyBindingsRequest.Identifier:
+                    HandleSetToggleWindowKeyBindingsRequest(args);
+                    break;
+                case TerminalExitedRequest.Identifier:
+                    HandleTerminalExitedRequest(args);
+                    break;
+                case GetAvailablePortRequest.Identifier:
+                    await HandleGetAvailablePortRequest(args);
+                    break;
+                case GetUserNameRequest.Identifier:
+                    await HandleGetUserNameRequest(args);
+                    break;
+                case SaveTextFileRequest.Identifier:
+                    await HandleSaveTextFileRequest(args);
+                    break;
+                default:
+                    Logger.Instance.Error("Received unknown message type: {messageType}", messageType);
+                    break;
             }
         }
 
-        private ValueSet CreateMessage(object content)
+        private void HandleWriteDataMessage(AppServiceRequestReceivedEventArgs args)
+        {
+            var terminalId = (int)args.Request.Message[MessageKeys.TerminalId];
+            var content = (byte[])args.Request.Message[MessageKeys.Content];
+            _terminalsManager.Write(terminalId, content);
+        }
+
+        private async Task HandleCreateTerminalRequest(AppServiceRequestReceivedEventArgs args)
+        {
+            var deferral = args.GetDeferral();
+            var messageContent = (string)args.Request.Message[MessageKeys.Content];
+            var request = JsonConvert.DeserializeObject<CreateTerminalRequest>(messageContent);
+            var response = _terminalsManager.CreateTerminal(request);
+            await args.Request.SendResponseAsync(CreateMessage(response));
+            deferral.Complete();
+        }
+
+        private void HandleResizeTerminalRequest(AppServiceRequestReceivedEventArgs args)
+        {
+            var messageContent = (string)args.Request.Message[MessageKeys.Content];
+            var request = JsonConvert.DeserializeObject<ResizeTerminalRequest>(messageContent);
+            _terminalsManager.ResizeTerminal(request.TerminalId, request.NewSize);
+        }
+
+        private void HandleSetToggleWindowKeyBindingsRequest(AppServiceRequestReceivedEventArgs args)
+        {
+            var messageContent = (string)args.Request.Message[MessageKeys.Content];
+            var request = JsonConvert.DeserializeObject<SetToggleWindowKeyBindingsRequest>(messageContent);
+            _toggleWindowService.SetHotKeys(request.KeyBindings);
+        }
+
+        private void HandleTerminalExitedRequest(AppServiceRequestReceivedEventArgs args)
+        {
+            var messageContent = (string)args.Request.Message[MessageKeys.Content];
+            var request = JsonConvert.DeserializeObject<TerminalExitedRequest>(messageContent);
+            _terminalsManager.CloseTerminal(request.TerminalId);
+        }
+
+        private async Task HandleGetAvailablePortRequest(AppServiceRequestReceivedEventArgs args)
+        {
+            var deferral = args.GetDeferral();
+            var response = new GetAvailablePortResponse { Port = Utilities.GetAvailablePort().Value };
+            await args.Request.SendResponseAsync(CreateMessage(response));
+            deferral.Complete();
+        }
+
+        private async Task HandleGetUserNameRequest(AppServiceRequestReceivedEventArgs args)
+        {
+            var deferral = args.GetDeferral();
+            var response = new GetUserNameResponse { UserName = Environment.UserName };
+            await args.Request.SendResponseAsync(CreateMessage(response));
+            deferral.Complete();
+        }
+
+        private async Task HandleSaveTextFileRequest(AppServiceRequestReceivedEventArgs args)
+        {
+            var deferral = args.GetDeferral();
+            var messageContent = (string)args.Request.Message[MessageKeys.Content];
+            var request = JsonConvert.DeserializeObject<SaveTextFileRequest>(messageContent);
+            var response = new CommonResponse();
+
+            try
+            {
+                Utilities.SaveFile(request.Path, request.Content);
+                response.Success = true;
+            }
+            catch (Exception e)
+            {
+                response.Success = false;
+                response.Error = e.Message;
+            }
+
+            await args.Request.SendResponseAsync(CreateMessage(response));
+
+            deferral.Complete();
+        }
+
+        private ValueSet CreateMessage(IMessage content)
         {
             return new ValueSet
             {
-                [MessageKeys.Type] = content.GetType().Name,
+                [MessageKeys.Type] = content.Identifier,
                 [MessageKeys.Content] = JsonConvert.SerializeObject(content)
             };
         }

--- a/FluentTerminal.SystemTray/Services/ConPty/ConPtySession.cs
+++ b/FluentTerminal.SystemTray/Services/ConPty/ConPtySession.cs
@@ -13,7 +13,7 @@ namespace FluentTerminal.SystemTray.Services.ConPty
         private bool _exited;
         private TerminalSize _terminalSize;
 
-        public int Id { get; private set; }
+        public byte Id { get; private set; }
 
         public string ShellExecutableName { get; private set; }
 

--- a/FluentTerminal.SystemTray/Services/ITerminalSession.cs
+++ b/FluentTerminal.SystemTray/Services/ITerminalSession.cs
@@ -6,7 +6,7 @@ namespace FluentTerminal.SystemTray.Services
 {
     public interface ITerminalSession : IDisposable
     {
-        int Id { get; }
+        byte Id { get; }
         string ShellExecutableName { get; }
 
         event EventHandler<int> ConnectionClosed;

--- a/FluentTerminal.SystemTray/Services/TerminalsManager.cs
+++ b/FluentTerminal.SystemTray/Services/TerminalsManager.cs
@@ -17,23 +17,17 @@ namespace FluentTerminal.SystemTray.Services
     public class TerminalsManager
     {
         private readonly Dictionary<int, ITerminalSession> _terminals = new Dictionary<int, ITerminalSession>();
-        private readonly ISettingsService _settingsService;
 
-        public event EventHandler<DisplayTerminalOutputRequest> DisplayOutputRequested;
+        public event EventHandler<TerminalOutput> DisplayOutputRequested;
 
         public event EventHandler<TerminalExitStatus> TerminalExited;
 
-        public TerminalsManager(ISettingsService settingsService)
-        {
-            _settingsService = settingsService;
-        }
-
         public void DisplayTerminalOutput(int terminalId, byte[] output)
         {
-            DisplayOutputRequested?.Invoke(this, new DisplayTerminalOutputRequest
+            DisplayOutputRequested?.Invoke(this, new TerminalOutput
             {
                 TerminalId = terminalId,
-                Output = output
+                Data = output
             });
         }
 

--- a/FluentTerminal.SystemTray/Services/TerminalsManager.cs
+++ b/FluentTerminal.SystemTray/Services/TerminalsManager.cs
@@ -16,13 +16,13 @@ namespace FluentTerminal.SystemTray.Services
 {
     public class TerminalsManager
     {
-        private readonly Dictionary<int, ITerminalSession> _terminals = new Dictionary<int, ITerminalSession>();
+        private readonly Dictionary<byte, ITerminalSession> _terminals = new Dictionary<byte, ITerminalSession>();
 
         public event EventHandler<TerminalOutput> DisplayOutputRequested;
 
         public event EventHandler<TerminalExitStatus> TerminalExited;
 
-        public void DisplayTerminalOutput(int terminalId, byte[] output)
+        public void DisplayTerminalOutput(byte terminalId, byte[] output)
         {
             DisplayOutputRequested?.Invoke(this, new TerminalOutput
             {
@@ -78,7 +78,7 @@ namespace FluentTerminal.SystemTray.Services
             };
         }
 
-        public void Write(int id, byte[] data)
+        public void Write(byte id, byte[] data)
         {
             if (_terminals.TryGetValue(id, out ITerminalSession terminal))
             {
@@ -86,7 +86,7 @@ namespace FluentTerminal.SystemTray.Services
             }
         }
 
-        public void ResizeTerminal(int id, TerminalSize size)
+        public void ResizeTerminal(byte id, TerminalSize size)
         {
             if (_terminals.TryGetValue(id, out ITerminalSession terminal))
             {
@@ -98,7 +98,7 @@ namespace FluentTerminal.SystemTray.Services
             }
         }
 
-        public void CloseTerminal(int id)
+        public void CloseTerminal(byte id)
         {
             if (_terminals.TryGetValue(id, out ITerminalSession terminal))
             {

--- a/FluentTerminal.SystemTray/Services/WinPty/WinPtySession.cs
+++ b/FluentTerminal.SystemTray/Services/WinPty/WinPtySession.cs
@@ -112,7 +112,7 @@ namespace FluentTerminal.SystemTray.Services.WinPty
 
         public event EventHandler<int> ConnectionClosed;
 
-        public int Id { get; private set; }
+        public byte Id { get; private set; }
 
         public string ShellExecutableName { get; private set; }
 


### PR DESCRIPTION
Somewhat similar to #232 

- Minimized message keys
- No more conversions between ValueSet and Dictionary
- Removed additional Request abstraction for sending buffers from/to terminal
- Remaining Requests are still serialized to JSON for now
- Changed datatype of terminal id to byte to squeeze out a few more bytes