### PR TITLE
Fix crash when any keybinding is changed

### DIFF
--- a/FluentTerminal.App.Services/Adapters/ApplicationDataContainerAdapter.cs
+++ b/FluentTerminal.App.Services/Adapters/ApplicationDataContainerAdapter.cs
@@ -51,12 +51,7 @@ namespace FluentTerminal.App.Services.Adapters
 
         public void WriteValueAsJson<T>(string name, T value)
         {
-            //_applicationDataContainer.Values[name] = JsonConvert.SerializeObject(value);
-            _applicationDataContainer.Values[name] = JsonConvert.SerializeObject(value, new JsonSerializerSettings()
-            {
-                PreserveReferencesHandling = PreserveReferencesHandling.All,
-                ReferenceLoopHandling = ReferenceLoopHandling.Serialize
-            });
+            _applicationDataContainer.Values[name] = JsonConvert.SerializeObject(value);
         }
     }
 }

--- a/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
@@ -253,11 +253,7 @@ namespace FluentTerminal.App.Services.Implementation
             return new ValueSet
             {
                 [MessageKeys.Type] = content.Identifier,
-                [MessageKeys.Content] = JsonConvert.SerializeObject(content, new JsonSerializerSettings()
-                {
-                    PreserveReferencesHandling = PreserveReferencesHandling.All,
-                    ReferenceLoopHandling = ReferenceLoopHandling.Serialize
-                })
+                [MessageKeys.Content] = JsonConvert.SerializeObject(content)
             };
         }
     }


### PR DESCRIPTION
This fixes a new regression introduced in 0065827bf (SSH profile support) which causes any keybinding change to crash FT. 

It's not clear to me why these JSON serializer settings were introduced so there might be a better way to fix this.