### PR TITLE
Clean up SSH keybindings

### DIFF
--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -121,6 +121,43 @@ namespace FluentTerminal.App.Services.Implementation
                         }
                     };
 
+                case Command.NewSshWindow:
+                    return new List<KeyBinding>
+                    {
+                        new KeyBinding
+                        {
+                            Command = nameof(Command.NewSshWindow),
+                            Ctrl = true,
+                            Alt = true,
+                            Key = (int)ExtendedVirtualKey.Y
+                        }
+                    };
+
+                case Command.SavedSshNewTab:
+                    return new List<KeyBinding>
+                    {
+                        new KeyBinding
+                        {
+                            Command = nameof(Command.SavedSshNewTab),
+                            Ctrl = true,
+                            Shift = true,
+                            Key = (int)ExtendedVirtualKey.U
+                        }
+                    };
+
+                case Command.SavedSshNewWindow:
+                    return new List<KeyBinding>
+                    {
+                        new KeyBinding
+                        {
+                            Command = nameof(Command.SavedSshNewWindow),
+                            Ctrl = true,
+                            Alt = true,
+                            Key = (int)ExtendedVirtualKey.U
+                        }
+                    };
+
+
                 case Command.ChangeTabTitle:
                     return new List<KeyBinding>
                 {
@@ -270,46 +307,6 @@ namespace FluentTerminal.App.Services.Implementation
                     }
                 };
 
-                case Command.SavedSshNewTab:
-                    return new List<KeyBinding>
-                    {
-                        new KeyBinding
-                        {
-                            Command = nameof(Command.SavedSshNewTab),
-                            Ctrl = true,
-                            Alt = true,
-                            Key = (int)ExtendedVirtualKey.Y
-                        }
-                    };
-
-                case Command.SavedSshNewWindow:
-                    return new List<KeyBinding>
-                    {
-                        new KeyBinding
-                        {
-                            Command = nameof(Command.SavedSshNewWindow),
-                            Ctrl = true,
-                            Alt = true,
-                            Shift = true,
-                            Key = (int)ExtendedVirtualKey.Z
-                        }
-                    };
-
-                case Command.NewSshWindow:
-                    return new List<KeyBinding>
-                    {
-                        new KeyBinding
-                        {
-                            Command = nameof(Command.NewSshWindow),
-                            Ctrl = true,
-                            Alt = true,
-                            Shift = true,
-                            Key = (int)ExtendedVirtualKey.Y
-                        }
-                    };
-
-
-                    
             }
 
             return null;

--- a/FluentTerminal.App/Strings/en/Resources.resw
+++ b/FluentTerminal.App/Strings/en/Resources.resw
@@ -790,7 +790,7 @@ Fuzzy</comment>
     <comment>Fuzzy</comment>
   </data>
   <data name="Command.NewSshTab" xml:space="preserve">
-    <value>New SSH Tab</value>
+    <value>New SSH tab</value>
   </data>
   <data name="SshInfoDialog.Title" xml:space="preserve">
     <value>SSH Info</value>
@@ -869,5 +869,14 @@ Fuzzy</comment>
   </data>
   <data name="ConfirmDeleteProfile" xml:space="preserve">
     <value>Are you sure you want to delete this profile?</value>
+  </data>
+  <data name="Command.NewSshWindow" xml:space="preserve">
+    <value>New SSH window</value>
+  </data>
+  <data name="Command.SavedSshNewTab" xml:space="preserve">
+    <value>New tab for SSH profile</value>
+  </data>
+  <data name="Command.SavedSshNewWindow" xml:space="preserve">
+    <value>New window for SSH profile</value>
   </data>
 </root>

--- a/FluentTerminal.App/Views/KeyBindingsView.xaml
+++ b/FluentTerminal.App/Views/KeyBindingsView.xaml
@@ -15,7 +15,7 @@
         </Grid.ColumnDefinitions>
         <TextBlock
             Grid.Column="0"
-            Width="180"
+            Width="200"
             Margin="0,6,24,0"
             Text="{x:Bind ViewModel.CommandName, Mode=OneWay}"
             Visibility="{x:Bind ShowCommandName, Mode=OneWay}" />

--- a/FluentTerminal.Models/Enums/Command.cs
+++ b/FluentTerminal.Models/Enums/Command.cs
@@ -6,12 +6,15 @@
         NextTab,
         PreviousTab,
         NewTab,
+        NewWindow,
         ConfigurableNewTab,
+        ConfigurableNewWindow,
         NewSshTab,
+        NewSshWindow,
+        SavedSshNewTab,
+        SavedSshNewWindow,
         ChangeTabTitle,
         CloseTab,
-        NewWindow,
-        ConfigurableNewWindow,
         ShowSettings,
         Copy,
         Paste,
@@ -28,9 +31,6 @@
         SwitchToTerm6,
         SwitchToTerm7,
         SwitchToTerm8,
-        SwitchToTerm9,
-        SavedSshNewTab,
-        SavedSshNewWindow,
-        NewSshWindow
+        SwitchToTerm9
     }
 }


### PR DESCRIPTION
- Added missing resource strings for new SSH bindings. Without these the settings page has no labels for these bindings.
- Rationalise default SSH keybindings. The logic is:
  - Adhoc SSH tabs and windows are based around the Y key
  - SSH profile tabs and windows are based around the U key (next to Y and easier to reach than Z)
- Reorder commands so that related keybindings are grouped together on the keybindings settings page
