### PR TITLE
Standardise on naming of SSH related functionality

### DIFF
--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -94,7 +94,7 @@ namespace FluentTerminal.App.ViewModels
             TabsPosition = _applicationSettings.TabsPosition;
 
             AddLocalShellCommand = new RelayCommand(async () => await AddLocalTabAsync());
-            AddRemoteShellCommand = new RelayCommand(async () => await AddSshTabAsync());
+            AddSshShellCommand = new RelayCommand(async () => await AddSshTabAsync());
             ShowAboutCommand = new RelayCommand(ShowAbout);
             ShowSettingsCommand = new RelayCommand(ShowSettings);
 
@@ -149,7 +149,7 @@ namespace FluentTerminal.App.ViewModels
         }
 
         public RelayCommand AddLocalShellCommand { get; }
-        public RelayCommand AddRemoteShellCommand { get; }
+        public RelayCommand AddSshShellCommand { get; }
 
         public string WindowTitle
         {

--- a/FluentTerminal.App/Strings/de/Resources.resw
+++ b/FluentTerminal.App/Strings/de/Resources.resw
@@ -748,7 +748,7 @@ Fuzzy</comment>
     <value>Fenster ein/ausblenden</value>
     <comment>Command</comment>
   </data>
-  <data name="NewRemoteTab.Text" xml:space="preserve">
+  <data name="NewSshTab.Text" xml:space="preserve">
     <value>Neuer SSH-Tab</value>
   </data>
   <data name="Command.NewSshTab" xml:space="preserve">

--- a/FluentTerminal.App/Strings/en/Resources.resw
+++ b/FluentTerminal.App/Strings/en/Resources.resw
@@ -785,8 +785,8 @@ Fuzzy</comment>
     <comment>Command
 Fuzzy</comment>
   </data>
-  <data name="NewRemoteTab.Text" xml:space="preserve">
-    <value>New remote tab</value>
+  <data name="NewSshTab.Text" xml:space="preserve">
+    <value>New SSH tab</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="Command.NewSshTab" xml:space="preserve">

--- a/FluentTerminal.App/Strings/es/Resources.resw
+++ b/FluentTerminal.App/Strings/es/Resources.resw
@@ -745,7 +745,7 @@
     <value>Cambiar ventana</value>
     <comment>Command</comment>
   </data>
-  <data name="NewRemoteTab.Text" xml:space="preserve">
+  <data name="NewSshTab.Text" xml:space="preserve">
     <value>Nueva pestaña remota</value>
   </data>
   <data name="Command.NewSshTab" xml:space="preserve">

--- a/FluentTerminal.App/Strings/zh-CN/Resources.resw
+++ b/FluentTerminal.App/Strings/zh-CN/Resources.resw
@@ -785,7 +785,7 @@ Fuzzy</comment>
     <comment>Command
 Fuzzy</comment>
   </data>
-  <data name="NewRemoteTab.Text" xml:space="preserve">
+  <data name="NewSshTab.Text" xml:space="preserve">
     <value>新的远程标签页</value>
     <comment>Fuzzy</comment>
   </data>

--- a/FluentTerminal.App/Views/MainPage.xaml
+++ b/FluentTerminal.App/Views/MainPage.xaml
@@ -55,8 +55,8 @@
                             </MenuFlyoutItem.Icon>
                         </MenuFlyoutItem>
                         <MenuFlyoutItem
-                            Command="{x:Bind ViewModel.AddRemoteShellCommand}"
-                            x:Uid="NewRemoteTab">
+                            Command="{x:Bind ViewModel.AddSshShellCommand}"
+                            x:Uid="NewSshTab">
                             <MenuFlyoutItem.Icon>
                                 <SymbolIcon Symbol="Add" />
                             </MenuFlyoutItem.Icon>


### PR DESCRIPTION
In some places code and UI referring to SSH connections and profiles used the word "remote". Standardise on "SSH" (this is used more often anyway).