### PR TITLE
Settings option to turn on Mosh by default for ssh connections

### DIFF
--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -25,7 +25,8 @@ namespace FluentTerminal.App.Services.Implementation
                 AlwaysShowTabs = false,
                 ShowNewOutputIndicator = false,
                 EnableTrayIcon = true,
-                ShowCustomTitleInTitlebar = true
+                ShowCustomTitleInTitlebar = true,
+                UseMoshByDefault = true
             };
         }
 

--- a/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
@@ -126,6 +126,20 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
+        public bool UseMoshByDefault
+        {
+            get => _applicationSettings.UseMoshByDefault;
+            set
+            {
+                if (_applicationSettings.UseMoshByDefault != value)
+                {
+                    _applicationSettings.UseMoshByDefault = value;
+                    _settingsService.SaveApplicationSettings(_applicationSettings);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
         public bool BottomIsSelected
         {
             get => TabsPosition == TabsPosition.Bottom;
@@ -290,6 +304,7 @@ namespace FluentTerminal.App.ViewModels.Settings
                 ShowNewOutputIndicator = defaults.ShowNewOutputIndicator;
                 EnableTrayIcon = defaults.EnableTrayIcon;
                 ShowCustomTitleInTitlebar = defaults.ShowCustomTitleInTitlebar;
+                UseMoshByDefault = defaults.UseMoshByDefault;
             }
         }
 

--- a/FluentTerminal.App.ViewModels/Settings/SshProfilesPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/SshProfilesPageViewModel.cs
@@ -99,7 +99,8 @@ namespace FluentTerminal.App.ViewModels.Settings
                 Id = Guid.NewGuid(),
                 PreInstalled = false,
                 Name = "New SSH profile",
-                KeyBindings = new List<KeyBinding>()
+                KeyBindings = new List<KeyBinding>(),
+                UseMosh = _settingsService.GetApplicationSettings().UseMoshByDefault
             };
 
             AddSshProfile(shellProfile);

--- a/FluentTerminal.App/Services/SshHelperService.cs
+++ b/FluentTerminal.App/Services/SshHelperService.cs
@@ -182,6 +182,8 @@ namespace FluentTerminal.App.Services
             SshProfileViewModel vm = new SshProfileViewModel(profile, _settingsService, _dialogService,
                 _fileSystemService, _applicationView, _defaultValueProvider, _trayProcessCommunicationService, true);
 
+            vm.UseMosh = _settingsService.GetApplicationSettings().UseMoshByDefault;
+
             vm = (SshProfileViewModel) await _dialogService.ShowSshConnectionInfoDialogAsync(vm);
 
             return (SshProfile) vm?.Model;

--- a/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
@@ -160,6 +160,12 @@
                     Margin="{StaticResource ItemMargin}"
                     Header="Show new output indicator on background tabs"
                     IsOn="{x:Bind ViewModel.ShowNewOutputIndicator, Mode=TwoWay}" />
+
+                <ToggleSwitch
+                    x:Uid="UseMoshByDefault"
+                    Margin="{StaticResource ItemMargin}"
+                    Header="Default to Mosh for SSH connections"
+                    IsOn="{x:Bind ViewModel.UseMoshByDefault, Mode=TwoWay}" />
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/FluentTerminal.Models/ApplicationSettings.cs
+++ b/FluentTerminal.Models/ApplicationSettings.cs
@@ -17,5 +17,6 @@ namespace FluentTerminal.Models
         public bool ShowNewOutputIndicator { get; set; }
         public bool EnableTrayIcon { get; set; }
         public bool ShowCustomTitleInTitlebar { get; set; }
+        public bool UseMoshByDefault { get; set; }
     }
 }


### PR DESCRIPTION
Adds settings option to use Mosh by default for ssh connections.

Requires translations for `UseMoshByDefault.Header` key in resources. Default string value from this PR is `Default to Mosh for SSH connections`.

PR related to https://github.com/jumptrading/FluentTerminal/issues/114

