### PR TITLE
Use patched xterm 3.14.1 with wordSeparator option

### DIFF
--- a/FluentTerminal.Client/package.json
+++ b/FluentTerminal.Client/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "cd node_modules\\xterm && npm install && npm run build && ren build dist",
     "build": "xcopy /y /s node_modules\\xterm\\dist\\xterm.css dist\\ && xcopy /y /s src\\style.css dist\\ && xcopy /y /s src\\index.html dist\\ && npx webpack --config webpack.config.js"
   },
   "author": "FS Apps",
@@ -16,6 +17,6 @@
     "webpack-cli": "^3.2.3"
   },
   "dependencies": {
-    "xterm": "^3.14.1"
+    "xterm": "https://github.com/MaxRis/xterm.js.git#3.14.1-patched"
   }
 }

--- a/FluentTerminal.Client/src/index.ts
+++ b/FluentTerminal.Client/src/index.ts
@@ -52,7 +52,8 @@ window.createTerminal = (options, theme, keyBindings) => {
     allowTransparency: true,
     theme: theme,
     windowsMode: true,
-    experimentalCharAtlas: "dynamic"
+    experimentalCharAtlas: "dynamic",
+    wordSeparator: ' ()[]{}\'":;'
   };
 
   term = new Terminal(terminalOptions);


### PR DESCRIPTION
Related to the Issue https://github.com/jumptrading/FluentTerminal/issues/106

Fluent updated to use patched xterm 4.14.1 from forked branch https://github.com/MaxRis/xterm.js/tree/3.14.1-patched

https://github.com/MaxRis/xterm.js/commit/0be6a73d3bceb8b3b9a77ba831bf4572ea01a286 introduces `wordSeparator` option as it was suggested there https://github.com/xtermjs/xterm.js/issues/2091

Fluent redefines words separators with additional ":" and ";" symbols to be recognized as separators.

