### PR TITLE
Use ConPTY by default for SSH connections

### DIFF
--- a/FluentTerminal.Models/SshProfile.cs
+++ b/FluentTerminal.Models/SshProfile.cs
@@ -1,5 +1,6 @@
 ﻿using FluentTerminal.Models.Enums;
 using System.Linq;
+using Windows.Foundation.Metadata;
 
 namespace FluentTerminal.Models
 {
@@ -36,6 +37,7 @@ namespace FluentTerminal.Models
         public SshProfile()
         {
             LineEndingTranslation = LineEndingStyle.ToLF;
+            UseConPty = ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7); // Windows 10 1809+
         }
 
         protected SshProfile(SshProfile other) : base(other)


### PR DESCRIPTION
Fixes #https://github.com/jumptrading/FluentTerminal/issues/133

ConPTY is selected by default for new SSH profiles and on new configurable SSH connections.