### PR TITLE
[Xterm.JS] Reset wrapped line flag.

### DIFF
--- a/FluentTerminal.Client/package.json
+++ b/FluentTerminal.Client/package.json
@@ -17,6 +17,6 @@
     "webpack-cli": "^3.2.3"
   },
   "dependencies": {
-    "xterm": "https://github.com/MaxRis/xterm.js.git#3.14.1-patched"
+    "xterm": "https://github.com/MaxRis/xterm.js.git#reset-wrapped-line-flag"
   }
 }


### PR DESCRIPTION
Incorporates fix from xterm.js's upstream https://github.com/xtermjs/xterm.js/pull/2278 .
Fixes #420