### PR TITLE
Settings option to right trim lines on coping to clipboard.

### DIFF
--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -27,7 +27,8 @@ namespace FluentTerminal.App.Services.Implementation
                 EnableTrayIcon = true,
                 ShowCustomTitleInTitlebar = true,
                 UseMoshByDefault = true,
-                AutoFallbackToWindowsUsernameInLinks = true
+                AutoFallbackToWindowsUsernameInLinks = true,
+                RTrimCopiedLines = true
             };
         }
 

--- a/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
@@ -154,6 +154,20 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
+        public bool RTrimCopiedLines
+        {
+            get => _applicationSettings.RTrimCopiedLines;
+            set
+            {
+                if (_applicationSettings.RTrimCopiedLines != value)
+                {
+                    _applicationSettings.RTrimCopiedLines = value;
+                    _settingsService.SaveApplicationSettings(_applicationSettings);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
         public bool BottomIsSelected
         {
             get => TabsPosition == TabsPosition.Bottom;

--- a/FluentTerminal.App/Services/ClipboardService.cs
+++ b/FluentTerminal.App/Services/ClipboardService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.DataTransfer;
 
@@ -6,6 +7,18 @@ namespace FluentTerminal.App.Services
 {
     public class ClipboardService : IClipboardService
     {
+        /// <summary>
+        /// Right trim whitespaces for each line.
+        /// </summary>
+        private static readonly Regex RTrimMultiLinesPattern = new Regex(@"([^\S\r\n]+)([\r\n])", RegexOptions.Compiled);
+
+        private readonly ISettingsService _settingsService;
+
+        public ClipboardService(ISettingsService settingsService)
+        {
+            _settingsService = settingsService;
+        }
+
         public Task<string> GetText()
         {
             var content = Clipboard.GetContent();
@@ -19,6 +32,10 @@ namespace FluentTerminal.App.Services
 
         public void SetText(string text)
         {
+            if (_settingsService.GetApplicationSettings().RTrimCopiedLines)
+            {
+                text = RTrimMultiLinesPattern.Replace(text, "$2");
+            }
             var dataPackage = new DataPackage();
             dataPackage.SetText(text);
             Clipboard.SetContent(dataPackage);

--- a/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
@@ -172,6 +172,12 @@
                     Margin="{StaticResource ItemMargin}"
                     Header="Use Windows username when opening SSH URLs that don't specify one"
                     IsOn="{x:Bind ViewModel.AutoFallbackToWindowsUsernameInLinks, Mode=TwoWay}" />
+
+                <ToggleSwitch
+                    x:Uid="RTrimCopiedLines"
+                    Margin="{StaticResource ItemMargin}"
+                    Header="Right trim copied lines"
+                    IsOn="{x:Bind ViewModel.RTrimCopiedLines, Mode=TwoWay}" />
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/FluentTerminal.Models/ApplicationSettings.cs
+++ b/FluentTerminal.Models/ApplicationSettings.cs
@@ -19,5 +19,6 @@ namespace FluentTerminal.Models
         public bool ShowCustomTitleInTitlebar { get; set; }
         public bool UseMoshByDefault { get; set; }
         public bool AutoFallbackToWindowsUsernameInLinks { get; set; }
+        public bool RTrimCopiedLines { get; set; }
     }
 }


### PR DESCRIPTION
Standard MacOS's Terminal.app and Ubuntu's terminal don't do right trimming of copied lines.

cmd.exe and iTerm2(MacOS) do right trimming.

Difference in copied white-spaces with/without turned on new added settings option:

![2019-06-30_3-31-29-rtrim-copied-lines-option](https://user-images.githubusercontent.com/1928902/60390810-a6519c80-9ae7-11e9-8d3f-c33958b00384.gif)

Related to https://github.com/jumptrading/FluentTerminal/issues/76