### PR TITLE
Settings option to mute conhost.

### DIFF
--- a/FluentTerminal.App.Services/ITrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/ITrayProcessCommunicationService.cs
@@ -35,5 +35,7 @@ namespace FluentTerminal.App.Services
         Task<string[]> GetFilesFromSshConfigDirAsync();
 
         Task<bool> CheckFileExistsAsync(string path);
+
+        void MuteTerminal(bool mute);
     }
 }

--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -29,7 +29,8 @@ namespace FluentTerminal.App.Services.Implementation
                 UseMoshByDefault = true,
                 AutoFallbackToWindowsUsernameInLinks = true,
                 UseQuickSshConnectByDefault = false,
-                RTrimCopiedLines = true
+                RTrimCopiedLines = true,
+                MuteTerminalBeeps = true
             };
         }
 

--- a/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
@@ -138,6 +138,11 @@ namespace FluentTerminal.App.Services.Implementation
             return JsonConvert.DeserializeObject<CommonResponse>((string) responseMessage[MessageKeys.Content]).Success;
         }
 
+        public void MuteTerminal(bool mute)
+        {
+            _appServiceConnection.SendMessageAsync(CreateMessage(new MuteTerminalRequest { Mute = mute }));
+        }
+
         public async Task<CreateTerminalResponse> CreateTerminal(byte id, TerminalSize size, ShellProfile shellProfile, SessionType sessionType)
         {
             var request = new CreateTerminalRequest

--- a/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
@@ -22,15 +22,17 @@ namespace FluentTerminal.App.ViewModels.Settings
         private string _startupTaskErrorMessage;
         private bool _needsToRestart;
         private readonly IApplicationLanguageService _applicationLanguageService;
+        private readonly ITrayProcessCommunicationService _trayProcessCommunicationService;
 
         public GeneralPageViewModel(ISettingsService settingsService, IDialogService dialogService, IDefaultValueProvider defaultValueProvider,
-            IStartupTaskService startupTaskService, IApplicationLanguageService applicationLanguageService)
+            IStartupTaskService startupTaskService, IApplicationLanguageService applicationLanguageService, ITrayProcessCommunicationService trayProcessCommunicationService)
         {
             _settingsService = settingsService;
             _dialogService = dialogService;
             _defaultValueProvider = defaultValueProvider;
             _startupTaskService = startupTaskService;
             _applicationLanguageService = applicationLanguageService;
+            _trayProcessCommunicationService = trayProcessCommunicationService;
 
             _applicationSettings = _settingsService.GetApplicationSettings();
 
@@ -178,6 +180,22 @@ namespace FluentTerminal.App.ViewModels.Settings
                     _applicationSettings.RTrimCopiedLines = value;
                     _settingsService.SaveApplicationSettings(_applicationSettings);
                     RaisePropertyChanged();
+                }
+            }
+        }
+
+        public bool MuteTerminalBeeps
+        {
+            get => _applicationSettings.MuteTerminalBeeps;
+            set
+            {
+                if (_applicationSettings.MuteTerminalBeeps != value)
+                {
+                    _applicationSettings.MuteTerminalBeeps = value;
+                    _settingsService.SaveApplicationSettings(_applicationSettings);
+                    RaisePropertyChanged();
+
+                    _trayProcessCommunicationService.MuteTerminal(value);
                 }
             }
         }
@@ -349,6 +367,7 @@ namespace FluentTerminal.App.ViewModels.Settings
                 UseMoshByDefault = defaults.UseMoshByDefault;
                 AutoFallbackToWindowsUsernameInLinks = defaults.AutoFallbackToWindowsUsernameInLinks;
                 RTrimCopiedLines = defaults.RTrimCopiedLines;
+                MuteTerminalBeeps = defaults.MuteTerminalBeeps;
             }
         }
 

--- a/FluentTerminal.App.ViewModels/SettingsViewModel.cs
+++ b/FluentTerminal.App.ViewModels/SettingsViewModel.cs
@@ -14,7 +14,7 @@ namespace FluentTerminal.App.ViewModels
         {
             About = new AboutPageViewModel(settingsService, updateService, applicationView);
             KeyBindings = new KeyBindingsPageViewModel(settingsService, dialogService, defaultValueProvider, trayProcessCommunicationService);
-            General = new GeneralPageViewModel(settingsService, dialogService, defaultValueProvider, startupTaskService, applicationLanguageService);
+            General = new GeneralPageViewModel(settingsService, dialogService, defaultValueProvider, startupTaskService, applicationLanguageService, trayProcessCommunicationService);
             Profiles = new ProfilesPageViewModel(settingsService, dialogService, defaultValueProvider, fileSystemService, applicationView);
             Terminal = new TerminalPageViewModel(settingsService, dialogService, defaultValueProvider, systemFontService);
             Themes = new ThemesPageViewModel(settingsService, dialogService, defaultValueProvider, themeParserFactory, fileSystemService);

--- a/FluentTerminal.App/Strings/en/Resources.resw
+++ b/FluentTerminal.App/Strings/en/Resources.resw
@@ -937,7 +937,8 @@ Fuzzy</comment>
     <value>Location cannot be empty.</value>
   </data>
   <data name="MuteTerminalBeeps.Header" xml:space="preserve">
-    <value></value>
+    <value>Mute terminal beeps</value>
+    <comment>GeneralSettings.xaml</comment>
   </data>
   <data name="UseCommandInput.Content" xml:space="preserve">
     <value>Use quick SSH</value>

--- a/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
@@ -184,6 +184,12 @@
                     Margin="{StaticResource ItemMargin}"
                     Header="Right trim copied lines"
                     IsOn="{x:Bind ViewModel.RTrimCopiedLines, Mode=TwoWay}" />
+
+                <ToggleSwitch
+                    x:Uid="MuteTerminalBeeps"
+                    Margin="{StaticResource ItemMargin}"
+                    Header="Mute terminal beeps"
+                    IsOn="{x:Bind ViewModel.MuteTerminalBeeps, Mode=TwoWay}" />
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/FluentTerminal.Models/ApplicationSettings.cs
+++ b/FluentTerminal.Models/ApplicationSettings.cs
@@ -21,5 +21,6 @@ namespace FluentTerminal.Models
         public bool AutoFallbackToWindowsUsernameInLinks { get; set; }
         public bool UseQuickSshConnectByDefault { get; set; }
         public bool RTrimCopiedLines { get; set; }
+        public bool MuteTerminalBeeps { get; set; }
     }
 }

--- a/FluentTerminal.Models/Requests/MuteTerminalRequest.cs
+++ b/FluentTerminal.Models/Requests/MuteTerminalRequest.cs
@@ -1,0 +1,11 @@
+﻿namespace FluentTerminal.Models.Requests
+{
+    public class MuteTerminalRequest : IMessage
+    {
+        public const byte Identifier = 14;
+
+        byte IMessage.Identifier => Identifier;
+
+        public bool Mute { get; set; }
+    }
+}

--- a/FluentTerminal.SystemTray/FluentTerminal.SystemTray.csproj
+++ b/FluentTerminal.SystemTray/FluentTerminal.SystemTray.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Services\WinPty\WinPtySession.cs" />
     <Compile Include="SystemTrayApplicationContext.cs" />
     <Compile Include="Utilities.cs" />
+    <Compile Include="VolumeControl.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/FluentTerminal.SystemTray/Program.cs
+++ b/FluentTerminal.SystemTray/Program.cs
@@ -90,6 +90,7 @@ namespace FluentTerminal.SystemTray
                 Task.Run(() => container.Resolve<IUpdateService>().CheckForUpdate());
 
                 var settingsService = container.Resolve<ISettingsService>();
+                Task.Run(() => Utilities.MuteTerminal(settingsService.GetApplicationSettings().MuteTerminalBeeps));
                 if (settingsService.GetApplicationSettings().EnableTrayIcon)
                 {
                     Application.Run(container.Resolve<SystemTrayApplicationContext>());

--- a/FluentTerminal.SystemTray/Services/AppCommunicationService.cs
+++ b/FluentTerminal.SystemTray/Services/AppCommunicationService.cs
@@ -117,6 +117,9 @@ namespace FluentTerminal.SystemTray.Services
                 case CheckFileExistsRequest.Identifier:
                     await HandleCheckFileExistsRequest(args);
                     break;
+                case MuteTerminalRequest.Identifier:
+                    await HandleMuteTerminalRequest(args);
+                    break;
                 default:
                     Logger.Instance.Error("Received unknown message type: {messageType}", messageType);
                     break;
@@ -233,6 +236,13 @@ namespace FluentTerminal.SystemTray.Services
             await args.Request.SendResponseAsync(CreateMessage(response));
 
             deferral.Complete();
+        }
+
+        private async Task HandleMuteTerminalRequest(AppServiceRequestReceivedEventArgs args)
+        {
+            var messageContent = (string)args.Request.Message[MessageKeys.Content];
+            var request = JsonConvert.DeserializeObject<MuteTerminalRequest>(messageContent);
+            Utilities.MuteTerminal(request.Mute);
         }
 
         private async Task HandleCheckFileExistsRequest(AppServiceRequestReceivedEventArgs args)

--- a/FluentTerminal.SystemTray/Utilities.cs
+++ b/FluentTerminal.SystemTray/Utilities.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.NetworkInformation;
@@ -565,6 +566,50 @@ namespace FluentTerminal.SystemTray
             using (StreamWriter writer = new StreamWriter(path, false))
             {
                 writer.Write(content);
+            }
+        }
+
+        internal static void MuteTerminal(bool mute)
+        {
+            bool? deviceMuted = VolumeControl.GetDefaultAudioEndpointMute();
+            if (deviceMuted != true)
+            {
+                VolumeControl.SetDefaultAudioEndpointMute(true);
+            }
+
+            Process cmdProcess = new Process();
+            cmdProcess.StartInfo.FileName = "cmd.exe";
+            cmdProcess.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+            cmdProcess.StartInfo.Arguments = "/k \x07";
+            cmdProcess.Start();
+
+            bool wasConhostMuted = false;
+            int attempt = 0;
+            while (wasConhostMuted == false && attempt++ < 2 && !cmdProcess.HasExited)
+            {
+                cmdProcess.WaitForExit(1500);
+
+                foreach (Process conhost in Process.GetProcessesByName("conhost"))
+                {
+                    try
+                    {
+                        bool? isMuted = null;
+                        isMuted = VolumeControl.GetAudioSessionMute(conhost.Id);
+                        if (isMuted != null && isMuted != mute)
+                        {
+                            VolumeControl.SetAudioSessionMute(conhost.Id, mute);
+                            wasConhostMuted = true;
+                            Logger.Instance.Debug($"Mute state for conhost process with id={conhost.Id} was set to {mute}.");
+                        }
+                    }
+                    catch (Exception) { }
+                }
+            }
+
+            cmdProcess.Kill();
+            if (deviceMuted != true)
+            {
+                VolumeControl.SetDefaultAudioEndpointMute(false);
             }
         }
     }

--- a/FluentTerminal.SystemTray/VolumeControl.cs
+++ b/FluentTerminal.SystemTray/VolumeControl.cs
@@ -1,0 +1,224 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace FluentTerminal.SystemTray
+{
+    public static class VolumeControl
+    {
+        public static bool? GetAudioSessionMute(int processId)
+        {
+            ISimpleAudioVolume volume = GetAudioVolume(processId);
+            if (volume == null)
+                return null;
+
+            volume.GetMute(out var mute);
+            Marshal.ReleaseComObject(volume);
+            return mute;
+        }
+
+        public static void SetAudioSessionMute(int processId, bool mute)
+        {
+            ISimpleAudioVolume volume = GetAudioVolume(processId);
+            if (volume == null)
+                return;
+
+            Guid guid = Guid.Empty;
+            volume.SetMute(mute, ref guid);
+            Marshal.ReleaseComObject(volume);
+        }
+
+        public static bool? GetDefaultAudioEndpointMute()
+        {
+            IMMDevice speakers = GetDefaultDevice();
+
+            Guid IID_IAudioEndpointVolume = typeof(IAudioEndpointVolume).GUID;
+            speakers.Activate(ref IID_IAudioEndpointVolume, 0, IntPtr.Zero, out var result);
+            IAudioEndpointVolume audioEndpoint = (IAudioEndpointVolume)result;
+            if (audioEndpoint == null)
+                return null;
+
+            audioEndpoint.GetMute(out var mute);
+            Marshal.ReleaseComObject(audioEndpoint);
+            return mute;
+        }
+
+        public static void SetDefaultAudioEndpointMute(bool mute)
+        {
+            IMMDevice speakers = GetDefaultDevice();
+
+            Guid IID_IAudioEndpointVolume = typeof(IAudioEndpointVolume).GUID;
+            speakers.Activate(ref IID_IAudioEndpointVolume, 0, IntPtr.Zero, out var result);
+            IAudioEndpointVolume audioEndpoint = (IAudioEndpointVolume)result;
+            if (audioEndpoint == null)
+                return;
+
+            Guid guid = Guid.Empty;
+            audioEndpoint.SetMute(mute, ref guid);
+            Marshal.ReleaseComObject(audioEndpoint);
+        }
+
+        private static IMMDevice GetDefaultDevice()
+        {
+            IMMDeviceEnumerator deviceEnumerator = (IMMDeviceEnumerator)(new MMDeviceEnumerator());
+            deviceEnumerator.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia, out var device);
+            Marshal.ReleaseComObject(deviceEnumerator);
+            return device;
+        }
+
+        private static ISimpleAudioVolume GetAudioVolume(int pid)
+        {
+            IMMDevice device = GetDefaultDevice();
+            Guid IID_IAudioSessionManager2 = typeof(IAudioSessionManager2).GUID;
+            device.Activate(ref IID_IAudioSessionManager2, 0, IntPtr.Zero, out var result);
+            IAudioSessionManager2 sessionManager = (IAudioSessionManager2)result;
+
+            sessionManager.GetSessionEnumerator(out var sessionEnumerator);
+            sessionEnumerator.GetCount(out var count);
+
+            ISimpleAudioVolume volumeControl = null;
+            for (int i = 0; i < count; i++)
+            {
+                sessionEnumerator.GetSession(i, out var sessionControl2);
+                sessionControl2.GetProcessId(out var processId);
+
+                if (processId == pid)
+                {
+                    volumeControl = sessionControl2 as ISimpleAudioVolume;
+                    break;
+                }
+                Marshal.ReleaseComObject(sessionControl2);
+            }
+            Marshal.ReleaseComObject(sessionEnumerator);
+            Marshal.ReleaseComObject(sessionManager);
+            Marshal.ReleaseComObject(device);
+            return volumeControl;
+        }
+    }
+
+    [ComImport]
+    [Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
+    internal class MMDeviceEnumerator
+    {
+    }
+
+    internal enum EDataFlow
+    {
+        eRender,
+        eCapture,
+        eAll,
+        EDataFlow_enum_count
+    }
+
+    internal enum ERole
+    {
+        eConsole,
+        eMultimedia,
+        eCommunications,
+        ERole_enum_count
+    }
+
+    [Guid("5CDF2C82-841E-4546-9722-0CF74078229A"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IAudioEndpointVolume
+    {
+        int NoImp1();
+        int NoImp2();
+        int NoImp3();
+        int NoImp4();
+        int NoImp5();
+        int NoImp6();
+        int NoImp7();
+        int NoImp8();
+        int NoImp9();
+        int NoImp10();
+        int NoImp11();
+
+        [PreserveSig]
+        int SetMute([MarshalAs(UnmanagedType.Bool)] Boolean bMute, ref Guid pguidEventContext);
+
+        [PreserveSig]
+        int GetMute(out bool pbMute);
+    }
+
+    [Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IMMDeviceEnumerator
+    {
+        int NoImp1();
+
+        [PreserveSig]
+        int GetDefaultAudioEndpoint(EDataFlow dataFlow, ERole role, out IMMDevice ppDevice);
+    }
+
+    [Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IMMDevice
+    {
+        [PreserveSig]
+        int Activate(ref Guid iid, int clsCtx, IntPtr pActivationParams, [MarshalAs(UnmanagedType.IUnknown)] out object ppInterface);
+    }
+
+    [Guid("77AA99A0-1BD6-484F-8BC7-2C654C9A9B6F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IAudioSessionManager2
+    {
+        int NoImp1();
+        int NoImp2();
+
+        [PreserveSig]
+        int GetSessionEnumerator(out IAudioSessionEnumerator SessionEnum);
+    }
+
+    [Guid("E2F5BB11-0570-40CA-ACDD-3AA01277DEE8"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IAudioSessionEnumerator
+    {
+        [PreserveSig]
+        int GetCount(out int SessionCount);
+
+        [PreserveSig]
+        int GetSession(int SessionCount, out IAudioSessionControl2 Session);
+    }
+
+    [Guid("87CE5498-68D6-44E5-9215-6DA47EF883D8"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface ISimpleAudioVolume
+    {
+        [PreserveSig]
+        int SetMasterVolume(float fLevel, ref Guid EventContext);
+
+        [PreserveSig]
+        int GetMasterVolume(out float pfLevel);
+
+        [PreserveSig]
+        int SetMute(bool bMute, ref Guid EventContext);
+
+        [PreserveSig]
+        int GetMute(out bool pbMute);
+    }
+
+    [Guid("bfb7ff88-7239-4fc9-8fa2-07c950be9c6d"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IAudioSessionControl2
+    {
+        // IAudioSessionControl
+        int NoImp0();
+        int NoImp1();
+        int NoImp2();
+        int NoImp3();
+        int NoImp4();
+        int NoImp5();
+        int NoImp6();
+        int NoImp7();
+        int NoImp8();
+
+        // IAudioSessionControl2
+        [PreserveSig]
+        int GetSessionIdentifier([MarshalAs(UnmanagedType.LPWStr)] out string pRetVal);
+
+        [PreserveSig]
+        int GetSessionInstanceIdentifier([MarshalAs(UnmanagedType.LPWStr)] out string pRetVal);
+
+        [PreserveSig]
+        int GetProcessId(out int pRetVal);
+
+        [PreserveSig]
+        int IsSystemSoundsSession();
+
+        [PreserveSig]
+        int SetDuckingPreference(bool optOut);
+    }
+}


### PR DESCRIPTION
Fixes #386 

- Global settings option is added to mute terminal beeps (mute state is applied to all currently running conhost processes with accessible audio sessions).
- On time of tray process startup global mute setting is applied.
- Default audio device is muted while manually generated beep to trigger conhost audio sessions is playing.