### PR TITLE
Settings option to dump terminal output into file.

### DIFF
--- a/FluentTerminal.App.Services/ISettingsService.cs
+++ b/FluentTerminal.App.Services/ISettingsService.cs
@@ -36,6 +36,7 @@ namespace FluentTerminal.App.Services
         IEnumerable<TerminalTheme> GetThemes();
         void ResetKeyBindings();
         void SaveApplicationSettings(ApplicationSettings applicationSettings);
+        void NotifyApplicationSettingsChanged(ApplicationSettings applicationSettings);
         void SaveCurrentThemeId(Guid id);
         void SaveDefaultShellProfileId(Guid id);
         void SaveDefaultSshProfileId(Guid id);

--- a/FluentTerminal.App.Services/ITrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/ITrayProcessCommunicationService.cs
@@ -37,5 +37,7 @@ namespace FluentTerminal.App.Services
         Task<bool> CheckFileExistsAsync(string path);
 
         void MuteTerminal(bool mute);
+
+        void UpdateSettings(ApplicationSettings settings);
     }
 }

--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -3,7 +3,9 @@ using FluentTerminal.Models;
 using FluentTerminal.Models.Enums;
 using System;
 using System.Collections.Generic;
+using Windows.ApplicationModel;
 using Windows.Foundation.Metadata;
+using Windows.Storage;
 
 namespace FluentTerminal.App.Services.Implementation
 {
@@ -11,6 +13,15 @@ namespace FluentTerminal.App.Services.Implementation
     {
         public ApplicationSettings GetDefaultApplicationSettings()
         {
+            var logDirectoryPath = String.Empty;
+            try
+            {
+                // Accessing ApplicationData.Current during run of unit tests causes
+                // "System.InvalidOperationException : The process has no package identity" exception.
+                logDirectoryPath = ApplicationData.Current.LocalCacheFolder.Path;
+            }
+            catch (InvalidOperationException) { }
+
             return new ApplicationSettings
             {
                 ConfirmClosingTabs = false,
@@ -30,7 +41,10 @@ namespace FluentTerminal.App.Services.Implementation
                 AutoFallbackToWindowsUsernameInLinks = true,
                 UseQuickSshConnectByDefault = false,
                 RTrimCopiedLines = true,
-                MuteTerminalBeeps = true
+                MuteTerminalBeeps = true,
+                EnableLogging = false,
+                PrintableOutputOnly = true,
+                LogDirectoryPath = logDirectoryPath
             };
         }
 

--- a/FluentTerminal.App.Services/Implementation/SettingsService.cs
+++ b/FluentTerminal.App.Services/Implementation/SettingsService.cs
@@ -325,6 +325,11 @@ namespace FluentTerminal.App.Services.Implementation
             ApplicationSettingsChanged?.Invoke(this, applicationSettings);
         }
 
+        public void NotifyApplicationSettingsChanged(ApplicationSettings applicationSettings)
+        {
+            ApplicationSettingsChanged?.Invoke(this, applicationSettings);
+        }
+
         public void SaveCurrentThemeId(Guid id)
         {
             _roamingSettings.SetValue(CurrentThemeKey, id);

--- a/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
@@ -143,6 +143,11 @@ namespace FluentTerminal.App.Services.Implementation
             _appServiceConnection.SendMessageAsync(CreateMessage(new MuteTerminalRequest { Mute = mute }));
         }
 
+        public void UpdateSettings(ApplicationSettings settings)
+        {
+            _appServiceConnection.SendMessageAsync(CreateMessage(new UpdateSettingsRequest { Settings = settings }));
+        }
+
         public async Task<CreateTerminalResponse> CreateTerminal(byte id, TerminalSize size, ShellProfile shellProfile, SessionType sessionType)
         {
             var request = new CreateTerminalRequest

--- a/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
@@ -199,6 +199,47 @@ namespace FluentTerminal.App.ViewModels.Settings
                 }
             }
         }
+        public bool EnableLogging
+        {
+            get => _applicationSettings.EnableLogging;
+            set
+            {
+                if (_applicationSettings.EnableLogging != value)
+                {
+                    _applicationSettings.EnableLogging = value;
+                    _settingsService.SaveApplicationSettings(_applicationSettings);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public bool PrintableOutputOnly
+        {
+            get => _applicationSettings.PrintableOutputOnly;
+            set
+            {
+                if (_applicationSettings.PrintableOutputOnly != value)
+                {
+                    _applicationSettings.PrintableOutputOnly = value;
+                    _settingsService.SaveApplicationSettings(_applicationSettings);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public string LogDirectoryPath
+        {
+            get => _applicationSettings.LogDirectoryPath;
+            set
+            {
+                if (_applicationSettings.LogDirectoryPath != value)
+                {
+                    _applicationSettings.LogDirectoryPath = value;
+                    _settingsService.SaveApplicationSettings(_applicationSettings);
+                    RaisePropertyChanged();
+                }
+            }
+        }
 
         public bool BottomIsSelected
         {
@@ -368,6 +409,9 @@ namespace FluentTerminal.App.ViewModels.Settings
                 AutoFallbackToWindowsUsernameInLinks = defaults.AutoFallbackToWindowsUsernameInLinks;
                 RTrimCopiedLines = defaults.RTrimCopiedLines;
                 MuteTerminalBeeps = defaults.MuteTerminalBeeps;
+                EnableLogging = defaults.EnableLogging;
+                PrintableOutputOnly = defaults.PrintableOutputOnly;
+                LogDirectoryPath = defaults.LogDirectoryPath;
             }
         }
 

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -511,6 +511,7 @@ namespace FluentTerminal.App
         private void OnApplicationSettingsChanged(object sender, ApplicationSettings e)
         {
             _applicationSettings = e;
+            _trayProcessCommunicationService.UpdateSettings(e);
         }
 
         private void OnMainViewModelClosed(object sender, EventArgs e)

--- a/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
@@ -190,6 +190,30 @@
                     Margin="{StaticResource ItemMargin}"
                     Header="Mute terminal beeps"
                     IsOn="{x:Bind ViewModel.MuteTerminalBeeps, Mode=TwoWay}" />
+
+                <StackPanel Margin="{StaticResource ItemMargin}">
+                    <ToggleSwitch
+                        x:Uid="EnableLogging"
+                        Header="Enable Logging"
+                        IsOn="{x:Bind ViewModel.EnableLogging, Mode=TwoWay}" />
+                    <CheckBox
+                        x:Uid="PrintableOutputOnly"
+                        Content="Printable output only"
+                        IsEnabled="{x:Bind ViewModel.EnableLogging, Mode=OneWay}"
+                        IsChecked="{x:Bind ViewModel.PrintableOutputOnly, Mode=TwoWay}" />
+                    <StackPanel Orientation="Horizontal" Spacing="5">
+                        <TextBox
+                            x:Uid="LogDirectoryPath"
+                            Text="{x:Bind ViewModel.LogDirectoryPath, Mode=TwoWay}"
+                            IsEnabled="{x:Bind ViewModel.EnableLogging, Mode=OneWay}"
+                            MaxWidth="250" MinWidth="250" />
+                        <Button
+                            x:Uid="BrowseButton"
+                            Click="BrowseButtonOnClick"
+                            Content="Browse"
+                            IsEnabled="{x:Bind ViewModel.EnableLogging, Mode=OneWay}"/>
+                    </StackPanel>
+                </StackPanel>
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml.cs
+++ b/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml.cs
@@ -1,4 +1,6 @@
-﻿using FluentTerminal.App.ViewModels.Settings;
+﻿using System;
+using FluentTerminal.App.ViewModels.Settings;
+using Windows.Storage.Pickers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 
@@ -19,6 +21,17 @@ namespace FluentTerminal.App.Views.SettingsPages
             {
                 ViewModel = viewModel;
                 ViewModel.OnNavigatedTo();
+            }
+        }
+
+        private async void BrowseButtonOnClick(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+        {
+            var picker = new FolderPicker() { SuggestedStartLocation = PickerLocationId.ComputerFolder };
+            picker.FileTypeFilter.Add(".whatever"); // else a ComException is thrown
+            var folder = await picker.PickSingleFolderAsync();
+            if (folder != null)
+            {
+                ViewModel.LogDirectoryPath = folder?.Path;
             }
         }
     }

--- a/FluentTerminal.Models/ApplicationSettings.cs
+++ b/FluentTerminal.Models/ApplicationSettings.cs
@@ -22,5 +22,8 @@ namespace FluentTerminal.Models
         public bool UseQuickSshConnectByDefault { get; set; }
         public bool RTrimCopiedLines { get; set; }
         public bool MuteTerminalBeeps { get; set; }
+        public bool EnableLogging { get; set; }
+        public bool PrintableOutputOnly { get; set; }
+        public string LogDirectoryPath { get; set; }
     }
 }

--- a/FluentTerminal.Models/Requests/UpdateSettingsRequest.cs
+++ b/FluentTerminal.Models/Requests/UpdateSettingsRequest.cs
@@ -1,0 +1,11 @@
+﻿namespace FluentTerminal.Models.Requests
+{
+    public class UpdateSettingsRequest : IMessage
+    {
+        public const byte Identifier = 15;
+
+        byte IMessage.Identifier => Identifier;
+
+        public ApplicationSettings Settings { get; set; }
+    }
+}

--- a/FluentTerminal.SystemTray/Program.cs
+++ b/FluentTerminal.SystemTray/Program.cs
@@ -61,7 +61,7 @@ namespace FluentTerminal.SystemTray
                 containerBuilder.RegisterType<SystemTrayApplicationContext>().SingleInstance();
                 containerBuilder.RegisterType<AppCommunicationService>().SingleInstance();
                 containerBuilder.RegisterType<DefaultValueProvider>().As<IDefaultValueProvider>();
-                containerBuilder.RegisterType<SettingsService>().As<ISettingsService>();
+                containerBuilder.RegisterType<SettingsService>().As<ISettingsService>().SingleInstance();
                 containerBuilder.RegisterType<UpdateService>().As<IUpdateService>();
                 containerBuilder.RegisterInstance(Dispatcher.CurrentDispatcher).SingleInstance();
 


### PR DESCRIPTION
Introduces Settings options to
- enable/disable terminal output into log files (disabled by default)
- option to filter out escape sequences to be added into log files (enabled by default)
- path to directory where to create log files (default value is `ApplicationData.Current.LocalCacheFolder.Path` which usually equals to `C:\Users\%USERNAME%\AppData\Local\Packages\53621FSApps.FluentTerminal_87x1pks76srcp\LocalCache`)

Log files are created per terminal session and named to contain session creation timestamp and profile/executable name, for example, `20190708104435232_Powershell.log`.

Feature requested by https://github.com/jumptrading/FluentTerminal/issues/75