### PR TITLE
Web browser like tabs

### DIFF
--- a/FluentTerminal.App.Services/Constants.cs
+++ b/FluentTerminal.App.Services/Constants.cs
@@ -10,5 +10,6 @@
         public const string SshCommandName = "ssh";
         public const string MoshCommandName = "mosh";
         public const string ExecutedCommandsContainerName = "HistoryContainer";
+        public const string TerminalViewModelStateId = "TerminalViewModelState";
     }
 }

--- a/FluentTerminal.App.Services/ITrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/ITrayProcessCommunicationService.cs
@@ -14,6 +14,8 @@ namespace FluentTerminal.App.Services
 
         Task<CreateTerminalResponse> CreateTerminal(byte id, TerminalSize size, ShellProfile shellProfile, SessionType sessionType);
 
+        Task<PauseTerminalOutputResponse> PauseTerminalOutput(byte id, bool pause);
+
         Task ResizeTerminal(byte id, TerminalSize size);
 
         Task UpdateToggleWindowKeyBindings();

--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -33,7 +33,7 @@ namespace FluentTerminal.App.Services.Implementation
                 CopyOnSelect = false,
                 MouseMiddleClickAction = MouseAction.None,
                 MouseRightClickAction = MouseAction.ContextMenu,
-                AlwaysShowTabs = false,
+                AlwaysShowTabs = true,
                 ShowNewOutputIndicator = false,
                 EnableTrayIcon = true,
                 ShowCustomTitleInTitlebar = true,

--- a/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
@@ -168,6 +168,18 @@ namespace FluentTerminal.App.Services.Implementation
             return response;
         }
 
+        public async Task<PauseTerminalOutputResponse> PauseTerminalOutput(byte id, bool pause)
+        {
+            var request = new PauseTerminalOutputRequest
+            {
+                Id = id,
+                Pause = pause
+            };
+
+            var responseMessage = await _appServiceConnection.SendMessageAsync(CreateMessage(request));
+            return JsonConvert.DeserializeObject<PauseTerminalOutputResponse>((string)responseMessage[MessageKeys.Content]);
+        }
+
         public void Initialize(IAppServiceConnection appServiceConnection)
         {
             _appServiceConnection = appServiceConnection;

--- a/FluentTerminal.App.ViewModels/ITerminalView.cs
+++ b/FluentTerminal.App.ViewModels/ITerminalView.cs
@@ -1,8 +1,7 @@
-﻿using FluentTerminal.App.ViewModels;
-using FluentTerminal.Models;
+﻿using FluentTerminal.Models;
 using System.Threading.Tasks;
 
-namespace FluentTerminal.App.Views
+namespace FluentTerminal.App.ViewModels
 {
     public interface ITerminalView
     {
@@ -13,5 +12,6 @@ namespace FluentTerminal.App.Views
         Task FindNext(string searchText);
         Task FindPrevious(string searchText);
         Task FocusTerminal();
+        Task<string> SerializeXtermState();
     }
 }

--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -141,6 +141,13 @@ namespace FluentTerminal.App.ViewModels
 
         public event EventHandler ActivatedMv;
 
+        public event EventHandler<TerminalViewModel> TabTearedOff;
+
+        public void TearOffTab(TerminalViewModel model)
+        {
+            TabTearedOff?.Invoke(this, model);
+        }
+
         public void FocusWindow()
         {
             ActivatedMv?.Invoke(this, EventArgs.Empty);
@@ -313,12 +320,12 @@ namespace FluentTerminal.App.ViewModels
             }
         }
 
-        public Task AddTerminalAsync(ShellProfile profile)
+        public Task AddTerminalAsync(ShellProfile profile, string terminalState)
         {
             return ApplicationView.RunOnDispatcherThread(() =>
             {
                 var terminal = new TerminalViewModel(_settingsService, _trayProcessCommunicationService, _dialogService, _keyboardCommandService,
-                    _applicationSettings, profile, ApplicationView, _dispatcherTimer, _clipboardService);
+                    _applicationSettings, profile, ApplicationView, _dispatcherTimer, _clipboardService, terminalState);
 
                 terminal.Closed += OnTerminalClosed;
                 terminal.ShellTitleChanged += Terminal_ShellTitleChanged;
@@ -327,6 +334,16 @@ namespace FluentTerminal.App.ViewModels
 
                 SelectedTerminal = terminal;
             });
+        }
+
+        public Task AddTerminalAsync(ShellProfile profile)
+        {
+            return AddTerminalAsync(profile, "");
+        }
+
+        public Task AddTerminalAsync(string terminalState)
+        {
+            return AddTerminalAsync(new ShellProfile(), terminalState);
         }
 
         private void Terminal_CustomTitleChanged(object sender, string e)

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -457,6 +457,7 @@ namespace FluentTerminal.App
                     mainViewModel.ShowSettingsRequested += OnShowSettingsRequested;
                     mainViewModel.ShowAboutRequested += OnShowAboutRequested;
                     mainViewModel.ActivatedMv += OnMainViewActivated;
+                    mainViewModel.TabTearedOff += OnTabTearOff;
                     _mainViewModels.Add(mainViewModel);
                 }
 
@@ -474,6 +475,7 @@ namespace FluentTerminal.App
             viewModel.ShowSettingsRequested += OnShowSettingsRequested;
             viewModel.ShowAboutRequested += OnShowAboutRequested;
             viewModel.ActivatedMv += OnMainViewActivated;
+            viewModel.TabTearedOff += OnTabTearOff;
             _mainViewModels.Add(viewModel);
 
             return viewModel;
@@ -525,6 +527,7 @@ namespace FluentTerminal.App
                 viewModel.ShowSettingsRequested -= OnShowSettingsRequested;
                 viewModel.ShowAboutRequested -= OnShowAboutRequested;
                 viewModel.ActivatedMv -= OnMainViewActivated;
+                viewModel.TabTearedOff -= OnTabTearOff;
                 if (_activeWindowId == viewModel.ApplicationView.Id)
                 {
                     _activeWindowId = 0;
@@ -541,6 +544,14 @@ namespace FluentTerminal.App
                 Logger.Instance.Debug("MainViewModel with ApplicationView Id: {@id} activated.", viewModel.ApplicationView.Id);
                 _activeWindowId = viewModel.ApplicationView.Id;
             }
+        }
+
+        private async void OnTabTearOff(object sender, TerminalViewModel model)
+        {
+            Logger.Instance.Debug("App.xaml.cs on tab tear off");
+
+            var newViewModel = await CreateNewTerminalWindow().ConfigureAwait(true);
+            await newViewModel.AddTerminalAsync(await model.Serialize());
         }
 
         private async void OnNewWindowRequested(object sender, NewWindowRequestedEventArgs e)

--- a/FluentTerminal.App/FluentTerminal.App.csproj
+++ b/FluentTerminal.App/FluentTerminal.App.csproj
@@ -207,7 +207,6 @@
     </Compile>
     <Compile Include="Views\NoValueTemplateSelector.cs" />
     <Compile Include="Views\TerminalThemeTemplateSelector.cs" />
-    <Compile Include="Views\ITerminalView.cs" />
     <Compile Include="Views\TerminalView.xaml.cs">
       <DependentUpon>TerminalView.xaml</DependentUpon>
     </Compile>

--- a/FluentTerminal.App/Views/MainPage.xaml
+++ b/FluentTerminal.App/Views/MainPage.xaml
@@ -187,7 +187,10 @@
                 AddCommand="{x:Bind ViewModel.AddLocalShellCommand}"
                 ItemsSource="{x:Bind ViewModel.Terminals, Mode=OneWay}"
                 SelectedItem="{x:Bind ViewModel.SelectedTerminal, Mode=TwoWay}"
-                Visibility="{x:Bind ViewModel.ShowTabsOnTop, Mode=OneWay}" />
+                Visibility="{x:Bind ViewModel.ShowTabsOnTop, Mode=OneWay}"
+                TabDraggedOutside="TabBar_TabDraggedOutside"
+                TabWindowChanged="TabView_Drop"
+                TabDraggingCompleted="TabBar_TabDraggingCompleted" />
         </Grid>
         <ContentControl
             x:Name="TerminalContainer"
@@ -201,6 +204,9 @@
             AddCommand="{x:Bind ViewModel.AddLocalShellCommand}"
             ItemsSource="{x:Bind ViewModel.Terminals, Mode=OneWay}"
             SelectedItem="{x:Bind ViewModel.SelectedTerminal, Mode=TwoWay}"
-            Visibility="{x:Bind ViewModel.ShowTabsOnBottom, Mode=OneWay}" />
+            Visibility="{x:Bind ViewModel.ShowTabsOnBottom, Mode=OneWay}"
+            TabDraggedOutside="TabBar_TabDraggedOutside"
+            TabWindowChanged="TabView_Drop"
+            TabDraggingCompleted="TabBar_TabDraggingCompleted" />
     </Grid>
 </Page>

--- a/FluentTerminal.App/Views/MainPage.xaml.cs
+++ b/FluentTerminal.App/Views/MainPage.xaml.cs
@@ -98,14 +98,6 @@ namespace FluentTerminal.App.Views
             }
         }
 
-        private void TabView_TabDraggedOutside(object sender, Microsoft.Toolkit.Uwp.UI.Controls.TabDraggedOutsideEventArgs e)
-        {
-            if (e.Item is TerminalViewModel model)
-            {
-                ViewModel.TearOffTab(model);
-            }
-        }
-
         private async void TabView_Drop(object sender, DragEventArgs e)
         {
             if (e.DataView.Properties.TryGetValue(Constants.TerminalViewModelStateId, out object stateObj) && stateObj is string terminalViewModelState)

--- a/FluentTerminal.App/Views/MainPage.xaml.cs
+++ b/FluentTerminal.App/Views/MainPage.xaml.cs
@@ -2,12 +2,14 @@
 using FluentTerminal.App.ViewModels;
 using System;
 using System.ComponentModel;
+using System.Linq;
 using Windows.ApplicationModel.Core;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
+using FluentTerminal.App.Services;
 
 namespace FluentTerminal.App.Views
 {
@@ -93,6 +95,45 @@ namespace FluentTerminal.App.Views
             {
                 PropertyChanged(this, new PropertyChangedEventArgs(nameof(CoreTitleBarHeight)));
                 PropertyChanged(this, new PropertyChangedEventArgs(nameof(CoreTitleBarPadding)));
+            }
+        }
+
+        private void TabView_TabDraggedOutside(object sender, Microsoft.Toolkit.Uwp.UI.Controls.TabDraggedOutsideEventArgs e)
+        {
+            if (e.Item is TerminalViewModel model)
+            {
+                ViewModel.TearOffTab(model);
+            }
+        }
+
+        private async void TabView_Drop(object sender, DragEventArgs e)
+        {
+            if (e.DataView.Properties.TryGetValue(Constants.TerminalViewModelStateId, out object stateObj) && stateObj is string terminalViewModelState)
+            {
+                await ViewModel.AddTerminalAsync(terminalViewModelState);
+            }
+        }
+
+        private void TabBar_TabDraggedOutside(ListViewBase sender, DragItemsCompletedEventArgs args)
+        {
+            var item = args.Items.FirstOrDefault();
+            if (item is TerminalViewModel model)
+            {
+                ViewModel.TearOffTab(model);
+            }
+        }
+
+        private void TabBar_TabDraggingCompleted(object sender, TerminalViewModel model)
+        {
+            int position = ViewModel.Terminals.IndexOf(model);
+            ViewModel.Terminals.Remove(model);
+            if (ViewModel.Terminals.Count > 0)
+            {
+                ViewModel.SelectedTerminal = ViewModel.Terminals[Math.Max(0, position - 1)];
+            }
+            else
+            {
+                ViewModel.ApplicationView.TryClose();
             }
         }
     }

--- a/FluentTerminal.App/Views/TabBar.xaml
+++ b/FluentTerminal.App/Views/TabBar.xaml
@@ -47,10 +47,14 @@
                 x:Name="ListView"
                 AllowDrop="True"
                 Background="Transparent"
-                CanDragItems="True"
+                CanDragItems="true"
                 CanReorderItems="True"
                 ItemsSource="{x:Bind ItemsSource}"
-                SelectedItem="{x:Bind SelectedItem, Mode=TwoWay}">
+                SelectedItem="{x:Bind SelectedItem, Mode=TwoWay}"
+                DragEnter="ListView_DragEnter"
+                DragItemsStarting="ListView_DragItemsStarting"
+                DragItemsCompleted="ListView_DragItemsCompleted"
+                Drop="ListView_Drop">
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="viewmodels:TerminalViewModel">
                         <RelativePanel
@@ -232,7 +236,7 @@
                         <Setter Property="Foreground" Value="{ThemeResource ListViewItemForeground}" />
                         <Setter Property="TabNavigation" Value="Local" />
                         <Setter Property="IsHoldingEnabled" Value="True" />
-                        <Setter Property="AllowDrop" Value="False" />
+                        <Setter Property="AllowDrop" Value="True" />
                         <Setter Property="UseSystemFocusVisuals" Value="True" />
                         <Setter Property="FocusVisualMargin" Value="0" />
                         <Setter Property="FocusVisualPrimaryBrush" Value="{ThemeResource ListViewItemFocusVisualPrimaryBrush}" />

--- a/FluentTerminal.App/Views/TerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/TerminalView.xaml.cs
@@ -24,6 +24,7 @@ namespace FluentTerminal.App.Views
             _terminalView = new XtermTerminalView();
             TerminalContainer.Children.Add((UIElement)_terminalView);
             _terminalView.Initialize(ViewModel);
+            ViewModel.TerminalView = _terminalView;
         }
 
         public TerminalViewModel ViewModel { get; }

--- a/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
@@ -125,6 +125,11 @@ namespace FluentTerminal.App.Views
             return ExecuteScriptAsync($"changeTheme('{serialized}')");
         }
 
+        public async Task<string> SerializeXtermState()
+        {
+            return await ExecuteScriptAsync(@"serializeTerminal()");
+        }
+
         public Task FindNext(string searchText)
         {
             return ExecuteScriptAsync($"findNext('{searchText}')");
@@ -171,7 +176,7 @@ namespace FluentTerminal.App.Views
             var port = await ViewModel.TrayProcessCommunicationService.GetAvailablePort().ConfigureAwait(true);
             await CreateWebSocketServer(port.Port).ConfigureAwait(true);
             _connectedEvent.Wait();
-            var response = await ViewModel.Terminal.StartShellProcess(ViewModel.ShellProfile, size, sessionType).ConfigureAwait(true);
+            var response = await ViewModel.Terminal.StartShellProcess(ViewModel.ShellProfile, size, sessionType, ViewModel.XtermBufferState).ConfigureAwait(true);
             if (!response.Success)
             {
                 await ViewModel.DialogService.ShowMessageDialogAsnyc("Error", response.Error, DialogButton.OK).ConfigureAwait(true);

--- a/FluentTerminal.Client/src/index.ts
+++ b/FluentTerminal.Client/src/index.ts
@@ -2,6 +2,7 @@ import { Terminal, ITerminalOptions } from 'xterm';
 import { AttachAddon } from 'xterm-addon-attach';
 import { FitAddon } from 'xterm-addon-fit';
 import { SearchAddon } from 'xterm-addon-search';
+import * as SerializeAddon from "./xterm-addon-serialize/src/SerializeAddon";
 
 interface ExtendedWindow extends Window {
   keyBindings: any[];
@@ -15,6 +16,7 @@ interface ExtendedWindow extends Window {
   changeKeyBindings(keyBindings: any): void;
   findNext(content: string): void;
   findPrevious(content: string): void;
+  serializeTerminal() : void;
 }
 
 declare var window: ExtendedWindow;
@@ -22,8 +24,14 @@ declare var window: ExtendedWindow;
 let term: any;
 let fitAddon: any;
 let searchAddon: any;
+let serializeAddon: any;
 let socket: WebSocket;
 const terminalContainer = document.getElementById('terminal-container');
+
+window.serializeTerminal = () => {
+  let serialized = serializeAddon.serialize();
+  return serialized;
+}
 
 window.createTerminal = (options, theme, keyBindings) => {
   while (terminalContainer.children.length) {
@@ -59,6 +67,8 @@ window.createTerminal = (options, theme, keyBindings) => {
   term.loadAddon(searchAddon);
   fitAddon = new FitAddon();
   term.loadAddon(fitAddon);
+  serializeAddon = new SerializeAddon.SerializeAddon();
+  term.loadAddon(serializeAddon);
 
   window.term = term;
 
@@ -95,7 +105,7 @@ window.createTerminal = (options, theme, keyBindings) => {
   }
 
   term.attachCustomKeyEventHandler(function (e) {
-    if (e.type != "keydown"){
+    if (e.type != "keydown") {
       return true;
     }
     for (var i = 0; i < window.keyBindings.length; i++) {

--- a/FluentTerminal.Client/src/xterm-addon-serialize/src/SerializeAddon.ts
+++ b/FluentTerminal.Client/src/xterm-addon-serialize/src/SerializeAddon.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2019 The xterm.js authors. All rights reserved.
+ * @license MIT
+ */
+
+import { Terminal, ITerminalAddon } from 'xterm';
+
+function crop(value: number, from: number, to: number): number {
+  return Math.max(from, Math.min(value, to));
+}
+
+export class SerializeAddon implements ITerminalAddon {
+  private _terminal: Terminal | undefined;
+
+  constructor() { }
+
+  public activate(terminal: Terminal): void {
+    this._terminal = terminal;
+  }
+
+  public serialize(rows?: number): string {
+    // TODO: Add frontground/background color support later
+    if (!this._terminal) {
+      throw new Error('Cannot use addon until it has been loaded');
+    }
+    const terminalRows = this._terminal.buffer.baseY + this._terminal.buffer.cursorY + 1;
+    if (rows === undefined) {
+      rows = terminalRows;
+    }
+    rows = crop(rows, 0, terminalRows);
+
+    const buffer = this._terminal.buffer;
+    const lines: string[] = new Array<string>(rows);
+
+    for (let i = terminalRows - rows; i < terminalRows; i++) {
+      const line = buffer.getLine(i);
+      lines[i - terminalRows + rows] = line ? line.translateToString(true) : '';
+    }
+
+    return lines.join('\r\n');
+  }
+
+  public dispose(): void { }
+}

--- a/FluentTerminal.Models/Requests/PauseTerminalOutputRequest.cs
+++ b/FluentTerminal.Models/Requests/PauseTerminalOutputRequest.cs
@@ -1,0 +1,13 @@
+﻿namespace FluentTerminal.Models.Requests
+{
+    public class PauseTerminalOutputRequest : IMessage
+    {
+        public const byte Identifier = 16;
+
+        byte IMessage.Identifier => Identifier;
+
+        public bool Pause { get; set; }
+
+        public byte Id { get; set; }
+    }
+}

--- a/FluentTerminal.Models/Responses/CreateTerminalResponse.cs
+++ b/FluentTerminal.Models/Responses/CreateTerminalResponse.cs
@@ -1,13 +1,11 @@
 ﻿namespace FluentTerminal.Models.Responses
 {
-    public class CreateTerminalResponse :IMessage
+    public class CreateTerminalResponse : TerminalResponse, IMessage
     {
         public const byte Identifier = 9;
 
         byte IMessage.Identifier => Identifier;
 
-        public bool Success { get; set; }
-        public string Error { get; set; }
         public string ShellExecutableName { get; set; }
     }
 }

--- a/FluentTerminal.Models/Responses/PauseTerminalOutputResponse.cs
+++ b/FluentTerminal.Models/Responses/PauseTerminalOutputResponse.cs
@@ -1,0 +1,9 @@
+﻿namespace FluentTerminal.Models.Responses
+{
+    public class PauseTerminalOutputResponse : TerminalResponse, IMessage
+    {
+        public const byte Identifier = 16;
+
+        byte IMessage.Identifier => Identifier;
+    }
+}

--- a/FluentTerminal.Models/Responses/TerminalResponse.cs
+++ b/FluentTerminal.Models/Responses/TerminalResponse.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FluentTerminal.Models.Responses
+{
+    public class TerminalResponse
+    {
+        public bool Success { get; set; }
+        public string Error { get; set; }
+    }
+}

--- a/FluentTerminal.SystemTray/Services/AppCommunicationService.cs
+++ b/FluentTerminal.SystemTray/Services/AppCommunicationService.cs
@@ -125,6 +125,9 @@ namespace FluentTerminal.SystemTray.Services
                 case UpdateSettingsRequest.Identifier:
                     await HandleUpdateSettingsRequest(args);
                     break;
+                case PauseTerminalOutputRequest.Identifier:
+                    await HandlePauseTerminalOutputRequest(args);
+                    break;
                 default:
                     Logger.Instance.Error("Received unknown message type: {messageType}", messageType);
                     break;
@@ -255,6 +258,18 @@ namespace FluentTerminal.SystemTray.Services
             var messageContent = (string)args.Request.Message[MessageKeys.Content];
             var request = JsonConvert.DeserializeObject<UpdateSettingsRequest>(messageContent);
             _settingsService.NotifyApplicationSettingsChanged(request.Settings);
+        }
+        
+        private async Task HandlePauseTerminalOutputRequest(AppServiceRequestReceivedEventArgs args)
+        {
+            var deferral = args.GetDeferral();
+            var messageContent = (string)args.Request.Message[MessageKeys.Content];
+            var request = JsonConvert.DeserializeObject<PauseTerminalOutputRequest>(messageContent);
+            var response = _terminalsManager.PauseTermimal(request.Id, request.Pause);
+
+            await args.Request.SendResponseAsync(CreateMessage(response));
+
+            deferral.Complete();
         }
 
         private async Task HandleCheckFileExistsRequest(AppServiceRequestReceivedEventArgs args)

--- a/FluentTerminal.SystemTray/Services/ConPty/ConPtySession.cs
+++ b/FluentTerminal.SystemTray/Services/ConPty/ConPtySession.cs
@@ -11,6 +11,7 @@ namespace FluentTerminal.SystemTray.Services.ConPty
         private TerminalsManager _terminalsManager;
         private Terminal _terminal;
         private bool _exited;
+        private bool _paused;
         private TerminalSize _terminalSize;
 
         public byte Id { get; private set; }
@@ -92,6 +93,11 @@ namespace FluentTerminal.SystemTray.Services.ConPty
                         {
                             _terminalsManager.DisplayTerminalOutput(Id, read);
                         }
+
+                        while(_paused && !_exited)
+                        {
+                            await Task.Delay(50);
+                        }
                     }
                     while (!_exited);
                 }
@@ -101,6 +107,11 @@ namespace FluentTerminal.SystemTray.Services.ConPty
         public void Write(byte[] data)
         {
             _terminal.WriteToPseudoConsole(data);
+        }
+
+        public void Pause(bool value)
+        {
+            _paused = value;
         }
 
         #region IDisposable Support

--- a/FluentTerminal.SystemTray/Services/ITerminalSession.cs
+++ b/FluentTerminal.SystemTray/Services/ITerminalSession.cs
@@ -15,5 +15,6 @@ namespace FluentTerminal.SystemTray.Services
         void Resize(TerminalSize size);
         void Write(byte[] data);
         void Start(CreateTerminalRequest request, TerminalsManager terminalsManager);
+        void Pause(bool value);
     }
 }

--- a/FluentTerminal.SystemTray/Services/TerminalsManager.cs
+++ b/FluentTerminal.SystemTray/Services/TerminalsManager.cs
@@ -173,6 +173,19 @@ namespace FluentTerminal.SystemTray.Services
             }
         }
 
+        public PauseTerminalOutputResponse PauseTermimal(byte id, bool pause)
+        {
+            var response = new PauseTerminalOutputResponse()
+            {
+                Success = true
+            };
+            if (_terminals.TryGetValue(id, out TerminalSessionInfo sessionInfo))
+            {
+                sessionInfo.Session.Pause(pause);
+            }
+            return response;
+        }
+
         public string GetDefaultEnvironmentVariableString(Dictionary<string, string> additionalVariables)
         {
             var environmentVariables = Environment.GetEnvironmentVariables();

--- a/FluentTerminal.SystemTray/Services/WinPty/WinPtySession.cs
+++ b/FluentTerminal.SystemTray/Services/WinPty/WinPtySession.cs
@@ -19,6 +19,7 @@ namespace FluentTerminal.SystemTray.Services.WinPty
         private TerminalsManager _terminalsManager;
         private Process _shellProcess;
         private bool _exited;
+        private bool _paused;
         private TerminalSize _terminalSize;
 
         public void Start(CreateTerminalRequest request, TerminalsManager terminalsManager)
@@ -211,10 +212,20 @@ namespace FluentTerminal.SystemTray.Services.WinPty
                         {
                             _terminalsManager.DisplayTerminalOutput(Id, read);
                         }
+
+                        while (_paused && !_exited)
+                        {
+                            await Task.Delay(50);
+                        }
                     }
                     while (!_exited);
                 }
             }, TaskCreationOptions.LongRunning);
+        }
+
+        public void Pause(bool value)
+        {
+            _paused = value;
         }
     }
 }


### PR DESCRIPTION
Related to https://github.com/jumptrading/FluentTerminal/issues/109

- TabBar.xaml extended to support tabs drag and drop events to allow tabs dropping to another window or to tear off tab and create new window.
- Pause and resume TerminalSession's std output reading while xterm.js is not listening.
- Enable AlwaysShowTabs Settings option by default.

Known issue to be addressed in next step:
Not whole state of xterm.js is restored on drop of tab for restored buffer content (but new received terminal session is displaying fine).