### PR TITLE
Remove the "Always show tabs" option

### DIFF
--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -33,7 +33,6 @@ namespace FluentTerminal.App.Services.Implementation
                 CopyOnSelect = false,
                 MouseMiddleClickAction = MouseAction.None,
                 MouseRightClickAction = MouseAction.ContextMenu,
-                AlwaysShowTabs = true,
                 ShowNewOutputIndicator = false,
                 EnableTrayIcon = true,
                 ShowCustomTitleInTitlebar = true,

--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -170,12 +170,12 @@ namespace FluentTerminal.App.ViewModels
 
         public bool ShowTabsOnTop
         {
-            get => TabsPosition == TabsPosition.Top && (Terminals.Count > 1 || _applicationSettings.AlwaysShowTabs);
+            get => TabsPosition == TabsPosition.Top;
         }
 
         public bool ShowTabsOnBottom
         {
-            get => TabsPosition == TabsPosition.Bottom && (Terminals.Count > 1 || _applicationSettings.AlwaysShowTabs);
+            get => TabsPosition == TabsPosition.Bottom;
         }
 
         public string Background

--- a/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
@@ -63,20 +63,6 @@ namespace FluentTerminal.App.ViewModels.Settings
             SetStartupTaskPropertiesForStatus(startupTaskStatus);
         }
 
-        public bool AlwaysShowTabs
-        {
-            get => _applicationSettings.AlwaysShowTabs;
-            set
-            {
-                if (_applicationSettings.AlwaysShowTabs != value)
-                {
-                    _applicationSettings.AlwaysShowTabs = value;
-                    _settingsService.SaveApplicationSettings(_applicationSettings);
-                    RaisePropertyChanged();
-                }
-            }
-        }
-
         public bool ShowCustomTitleInTitlebar
         {
             get => _applicationSettings.ShowCustomTitleInTitlebar;
@@ -401,7 +387,6 @@ namespace FluentTerminal.App.ViewModels.Settings
                 UnderlineSelectedTab = defaults.UnderlineSelectedTab;
                 InactiveTabColorMode = defaults.InactiveTabColorMode;
                 NewTerminalLocation = defaults.NewTerminalLocation;
-                AlwaysShowTabs = defaults.AlwaysShowTabs;
                 ShowNewOutputIndicator = defaults.ShowNewOutputIndicator;
                 EnableTrayIcon = defaults.EnableTrayIcon;
                 ShowCustomTitleInTitlebar = defaults.ShowCustomTitleInTitlebar;

--- a/FluentTerminal.App/Strings/de/Resources.resw
+++ b/FluentTerminal.App/Strings/de/Resources.resw
@@ -121,10 +121,6 @@
     <value>Über</value>
     <comment>MainPage.xaml</comment>
   </data>
-  <data name="AlwaysShowTabs.Header" xml:space="preserve">
-    <value>Tableiste immer anzeigen</value>
-    <comment>GeneralSettings.xaml</comment>
-  </data>
   <data name="Background.Content" xml:space="preserve">
     <value>Hintergrund</value>
     <comment>GeneralSettings.xaml</comment>

--- a/FluentTerminal.App/Strings/en/Resources.resw
+++ b/FluentTerminal.App/Strings/en/Resources.resw
@@ -121,10 +121,6 @@
     <value>About</value>
     <comment>MainPage.xaml</comment>
   </data>
-  <data name="AlwaysShowTabs.Header" xml:space="preserve">
-    <value>Always show tabs</value>
-    <comment>GeneralSettings.xaml</comment>
-  </data>
   <data name="Background.Content" xml:space="preserve">
     <value>Background</value>
     <comment>GeneralSettings.xaml</comment>

--- a/FluentTerminal.App/Strings/es/Resources.resw
+++ b/FluentTerminal.App/Strings/es/Resources.resw
@@ -121,10 +121,6 @@
     <value>Acerca de...</value>
     <comment>MainPage.xaml</comment>
   </data>
-  <data name="AlwaysShowTabs.Header" xml:space="preserve">
-    <value>Mostrar siempre las pestañas</value>
-    <comment>GeneralSettings.xaml</comment>
-  </data>
   <data name="Background.Content" xml:space="preserve">
     <value>Fondo</value>
     <comment>GeneralSettings.xaml</comment>

--- a/FluentTerminal.App/Strings/zh-CN/Resources.resw
+++ b/FluentTerminal.App/Strings/zh-CN/Resources.resw
@@ -121,10 +121,6 @@
     <value>关于</value>
     <comment>MainPage.xaml</comment>
   </data>
-  <data name="AlwaysShowTabs.Header" xml:space="preserve">
-    <value>始终显示标签栏</value>
-    <comment>GeneralSettings.xaml</comment>
-  </data>
   <data name="Background.Content" xml:space="preserve">
     <value>背景色</value>
     <comment>GeneralSettings.xaml</comment>

--- a/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
@@ -109,12 +109,6 @@
                 </StackPanel>
 
                 <ToggleSwitch
-                    x:Uid="AlwaysShowTabs"
-                    Margin="{StaticResource ItemMargin}"
-                    Header="Always show tabs"
-                    IsOn="{x:Bind ViewModel.AlwaysShowTabs, Mode=TwoWay}" />
-
-                <ToggleSwitch
                     x:Uid="CustomTitle"
                     Margin="{StaticResource ItemMargin}"
                     Header="Show custom tab title also in titlebar"

--- a/FluentTerminal.Models/ApplicationSettings.cs
+++ b/FluentTerminal.Models/ApplicationSettings.cs
@@ -13,7 +13,6 @@ namespace FluentTerminal.Models
         public bool CopyOnSelect { get; set; }
         public MouseAction MouseMiddleClickAction { get; set; }
         public MouseAction MouseRightClickAction { get; set; }
-        public bool AlwaysShowTabs { get; set; }
         public bool ShowNewOutputIndicator { get; set; }
         public bool EnableTrayIcon { get; set; }
         public bool ShowCustomTitleInTitlebar { get; set; }


### PR DESCRIPTION
Now that tags are draggable between windows this option will mainly cause confusion.

Follows on from #467.