### PR TITLE
Show tab close button on hover.

### DIFF
--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -351,10 +351,54 @@ namespace FluentTerminal.App.ViewModels
                 terminal.Closed += OnTerminalClosed;
                 terminal.ShellTitleChanged += Terminal_ShellTitleChanged;
                 terminal.CustomTitleChanged += Terminal_CustomTitleChanged;
+                terminal.CloseLeftTabsRequested += Terminal_CloseLeftTabsRequested;
+                terminal.CloseRightTabsRequested += Terminal_CloseRightTabsRequested;
+                terminal.CloseOtherTabsRequested += Terminal_CloseOtherTabsRequested;
                 Terminals.Insert(position, terminal);
 
                 SelectedTerminal = terminal;
             });
+        }
+
+        private void Terminal_CloseOtherTabsRequested(object sender, EventArgs e)
+        {
+            if (sender is TerminalViewModel terminal)
+            {
+                Array.ForEach<TerminalViewModel>(Terminals.ToArray(),
+                    t => {
+                        if (terminal != t)
+                        {
+                            Logger.Instance.Debug("Terminal with Id: {@id} closed.", t.Terminal.Id);
+                            t.CloseCommand.Execute(EventArgs.Empty);
+                        }
+                    });
+            }
+        }
+
+        private void Terminal_CloseRightTabsRequested(object sender, EventArgs e)
+        {
+            if (sender is TerminalViewModel terminal)
+            {
+                for (int i = Terminals.Count - 1; i > Terminals.IndexOf(terminal); --i)
+                {
+                    var terminalToRemove = Terminals[i];
+                    Logger.Instance.Debug("Terminal with Id: {@id} closed.", terminalToRemove.Terminal.Id);
+                    terminalToRemove.CloseCommand.Execute(EventArgs.Empty);
+                }
+            }
+        }
+
+        private void Terminal_CloseLeftTabsRequested(object sender, EventArgs e)
+        {
+            if (sender is TerminalViewModel terminal)
+            {
+                for(int i = Terminals.IndexOf(terminal) - 1; i >= 0; --i)
+                {
+                    var terminalToRemove = Terminals[i];
+                    Logger.Instance.Debug("Terminal with Id: {@id} closed.", terminalToRemove.Terminal.Id);
+                    terminalToRemove.CloseCommand.Execute(EventArgs.Empty);
+                }
+            }
         }
 
         public Task AddTerminalAsync(ShellProfile profile)

--- a/FluentTerminal.App.ViewModels/TerminalViewModel.cs
+++ b/FluentTerminal.App.ViewModels/TerminalViewModel.cs
@@ -119,6 +119,9 @@ namespace FluentTerminal.App.ViewModels
             TabTheme = TabThemes.FirstOrDefault(t => t.Id == ShellProfile.TabThemeId);
 
             CloseCommand = new RelayCommand(async () => await TryClose().ConfigureAwait(false));
+            CloseLeftTabsCommand = new RelayCommand(CloseLeftTabs);
+            CloseRightTabsCommand = new RelayCommand(CloseRightTabs);
+            CloseOtherTabsCommand = new RelayCommand(CloseOtherTabs);
             FindNextCommand = new RelayCommand(FindNext);
             FindPreviousCommand = new RelayCommand(FindPrevious);
             CloseSearchPanelCommand = new RelayCommand(CloseSearchPanel);
@@ -152,6 +155,9 @@ namespace FluentTerminal.App.ViewModels
         public event EventHandler<TerminalTheme> ThemeChanged;
         public event EventHandler<string> ShellTitleChanged;
         public event EventHandler<string> CustomTitleChanged;
+        public event EventHandler CloseLeftTabsRequested;
+        public event EventHandler CloseRightTabsRequested;
+        public event EventHandler CloseOtherTabsRequested;
 
         public ApplicationSettings ApplicationSettings { get; private set; }
 
@@ -171,6 +177,12 @@ namespace FluentTerminal.App.ViewModels
         public string XtermBufferState { get; private set; }
 
         public RelayCommand CloseCommand { get; }
+
+        public RelayCommand CloseRightTabsCommand { get; }
+
+        public RelayCommand CloseLeftTabsCommand { get; }
+
+        public RelayCommand CloseOtherTabsCommand { get; }
 
         public RelayCommand CloseSearchPanelCommand { get; }
 
@@ -370,6 +382,21 @@ namespace FluentTerminal.App.ViewModels
             FocusTerminal();
         }
 
+        private void CloseLeftTabs()
+        {
+            CloseLeftTabsRequested?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void CloseRightTabs()
+        {
+            CloseRightTabsRequested?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void CloseOtherTabs()
+        {
+            CloseOtherTabsRequested?.Invoke(this, EventArgs.Empty);
+        }
+
         private void FindNext()
         {
             FindNextRequested?.Invoke(this, SearchText);
@@ -511,7 +538,7 @@ namespace FluentTerminal.App.ViewModels
         {
             if (ApplicationSettings.ConfirmClosingTabs)
             {
-                var result = await DialogService.ShowMessageDialogAsnyc(I18N.Translate("PleaseConfirm"), I18N.Translate("ConfirmCloseTab"), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
+                var result = await DialogService.ShowMessageDialogAsnyc(I18N.Translate("PleaseConfirm"), String.Format(I18N.Translate("ConfirmCloseTab"), ShellTitle), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
 
                 if (result == DialogButton.Cancel)
                 {

--- a/FluentTerminal.App.ViewModels/TerminalViewModel.cs
+++ b/FluentTerminal.App.ViewModels/TerminalViewModel.cs
@@ -79,6 +79,7 @@ namespace FluentTerminal.App.ViewModels
 
         private readonly IKeyboardCommandService _keyboardCommandService;
         private bool _isSelected;
+        private bool _isHovered;
         private bool _hasNewOutput;
         private bool _hasExitedWithError;
         private string _searchText;
@@ -194,8 +195,26 @@ namespace FluentTerminal.App.ViewModels
                     }
                     RaisePropertyChanged(nameof(IsUnderlined));
                     RaisePropertyChanged(nameof(BackgroundTabTheme));
+                    RaisePropertyChanged(nameof(ShowCloseButton));
                 }
             }
+        }
+
+        public bool IsHovered
+        {
+            get => _isHovered;
+            set
+            {
+                if (Set(ref _isHovered, value))
+                {
+                    RaisePropertyChanged(nameof(ShowCloseButton));
+                }
+            }
+        }
+
+        public bool ShowCloseButton
+        {
+            get => IsHovered || IsSelected;
         }
 
         public bool IsUnderlined => (IsSelected && ApplicationSettings.UnderlineSelectedTab) ||

--- a/FluentTerminal.App/FluentTerminal.App.csproj
+++ b/FluentTerminal.App/FluentTerminal.App.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Converters\TrueToBoldConverter.cs" />
     <Compile Include="Converters\TrueToVisibleConverter.cs" />
     <Compile Include="Adapters\MessageDialogAdapter.cs" />
+    <Compile Include="Utilities\InteractiveSurface.cs" />
     <Compile Include="ViewModels\CommandItemViewModel.cs" />
     <Compile Include="Dialogs\CustomCommandDialog.xaml.cs">
       <DependentUpon>CustomCommandDialog.xaml</DependentUpon>

--- a/FluentTerminal.App/Strings/de/Resources.resw
+++ b/FluentTerminal.App/Strings/de/Resources.resw
@@ -541,7 +541,7 @@ Fuzzy</comment>
     <comment>ShellProfileSettings.xaml</comment>
   </data>
   <data name="ConfirmCloseTab" xml:space="preserve">
-    <value>Sind Sie sicher dass Sie diesen Tab schließen wollen?</value>
+    <value>Sind Sie sicher dass Sie "{0}" Tab schließen wollen?</value>
     <comment>ViewModel</comment>
   </data>
   <data name="ConfirmCloseWindow" xml:space="preserve">

--- a/FluentTerminal.App/Strings/en/Resources.resw
+++ b/FluentTerminal.App/Strings/en/Resources.resw
@@ -550,7 +550,7 @@ Fuzzy</comment>
     <comment>ShellProfileSettings.xaml</comment>
   </data>
   <data name="ConfirmCloseTab" xml:space="preserve">
-    <value>Are you sure you want to close this tab?</value>
+    <value>Are you sure you want to close "{0}" tab?</value>
     <comment>ViewModel</comment>
   </data>
   <data name="ConfirmCloseWindow" xml:space="preserve">
@@ -980,5 +980,17 @@ Fuzzy</comment>
   <data name="DropTabHere" xml:space="preserve">
     <value>Drop tab here</value>
     <comment>Drop hint</comment>
+  </data>
+  <data name="CloseLeft.Text" xml:space="preserve">
+    <value>Close Tabs to the Left</value>
+    <comment>TabBar.xaml</comment>
+  </data>
+  <data name="CloseOther.Text" xml:space="preserve">
+    <value>Close Other Tabs</value>
+    <comment>TabBar.xaml</comment>
+  </data>
+  <data name="CloseRight.Text" xml:space="preserve">
+    <value>Close Tabs to the Right</value>
+    <comment>TabBar.xaml</comment>
   </data>
 </root>

--- a/FluentTerminal.App/Strings/es/Resources.resw
+++ b/FluentTerminal.App/Strings/es/Resources.resw
@@ -539,7 +539,7 @@ Fuzzy</comment>
     <comment>ShellProfileSettings.xaml</comment>
   </data>
   <data name="ConfirmCloseTab" xml:space="preserve">
-    <value>¿Quieres cerrar esta pestaña?</value>
+    <value>¿Quieres cerrar "{0}" pestaña?</value>
     <comment>ViewModel</comment>
   </data>
   <data name="ConfirmCloseWindow" xml:space="preserve">

--- a/FluentTerminal.App/Strings/zh-CN/Resources.resw
+++ b/FluentTerminal.App/Strings/zh-CN/Resources.resw
@@ -538,7 +538,7 @@ Fuzzy</comment>
     <comment>ShellProfileSettings.xaml</comment>
   </data>
   <data name="ConfirmCloseTab" xml:space="preserve">
-    <value>是否要关闭此标签页？</value>
+    <value>是否要关闭"{0}"标签页？</value>
     <comment>ViewModel</comment>
   </data>
   <data name="ConfirmCloseWindow" xml:space="preserve">

--- a/FluentTerminal.App/Utilities/InteractiveSurface.cs
+++ b/FluentTerminal.App/Utilities/InteractiveSurface.cs
@@ -1,0 +1,36 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+
+namespace FluentTerminal.App.Utilities
+{
+    class InteractiveSurface : ContentControl
+    {
+        public static readonly DependencyProperty HoveredProperty =
+            DependencyProperty.Register(nameof(Hovered), typeof(bool), typeof(InteractiveSurface), new PropertyMetadata(false));
+
+        public bool Hovered
+        {
+            get => (bool)GetValue(HoveredProperty);
+            set => SetValue(HoveredProperty, value);
+        }
+
+        protected override void OnPointerEntered(PointerRoutedEventArgs e)
+        {
+            base.OnPointerEntered(e);
+            Hovered = true;
+        }
+
+        protected override void OnPointerCanceled(PointerRoutedEventArgs e)
+        {
+            base.OnPointerCanceled(e);
+            Hovered = false;
+        }
+
+        protected override void OnPointerExited(PointerRoutedEventArgs e)
+        {
+            base.OnPointerExited(e);
+            Hovered = false;
+        }
+    }
+}

--- a/FluentTerminal.App/Views/TabBar.xaml
+++ b/FluentTerminal.App/Views/TabBar.xaml
@@ -10,6 +10,7 @@
     xmlns:models="using:FluentTerminal.Models"
     xmlns:viewmodels="using:FluentTerminal.App.ViewModels"
     xmlns:views="using:FluentTerminal.App.Views"
+    xmlns:utilities="using:FluentTerminal.App.Utilities"
     d:DesignHeight="32"
     d:DesignWidth="200"
     mc:Ignorable="d">
@@ -57,169 +58,172 @@
                 Drop="ListView_Drop">
                 <ListView.ItemTemplate>
                     <DataTemplate x:DataType="viewmodels:TerminalViewModel">
-                        <RelativePanel
-                            Height="32"
-                            Margin="0"
-                            VerticalAlignment="Stretch"
-                            Background="Transparent"
-                            ToolTipService.ToolTip="{x:Bind TabTitle, Mode=OneWay}">
-
-                            <Interactivity:Interaction.Behaviors>
-                                <behaviors:MiddleClickBehavior>
-                                    <behaviors:MiddleClickBehavior.Actions>
-                                        <core:InvokeCommandAction Command="{x:Bind CloseCommand}" />
-                                    </behaviors:MiddleClickBehavior.Actions>
-                                </behaviors:MiddleClickBehavior>
-                            </Interactivity:Interaction.Behaviors>
-
-                            <RelativePanel.ContextFlyout>
-                                <MenuFlyout>
-                                    <MenuFlyoutSubItem x:Uid="Color">
-                                        <ToggleMenuFlyoutItem
-                                            Command="{x:Bind SelectTabThemeCommand}"
-                                            CommandParameter="0"
-                                            IsChecked="{x:Bind TabTheme, Mode=OneWay, Converter={StaticResource TabThemeSelectedConverter}, ConverterParameter=None}"
-                                            Text="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=TabTheme.None}">
-                                            <ToggleMenuFlyoutItem.Icon>
-                                                <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xF126;" />
-                                            </ToggleMenuFlyoutItem.Icon>
-                                        </ToggleMenuFlyoutItem>
-                                        <ToggleMenuFlyoutItem
-                                            Command="{x:Bind SelectTabThemeCommand}"
-                                            CommandParameter="1"
-                                            IsChecked="{x:Bind TabTheme, Mode=OneWay, Converter={StaticResource TabThemeSelectedConverter}, ConverterParameter=Red}"
-                                            Text="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=TabTheme.Red}">
-                                            <ToggleMenuFlyoutItem.Icon>
-                                                <FontIcon
-                                                    FontFamily="Segoe MDL2 Assets"
-                                                    Foreground="#E81123"
-                                                    Glyph="&#xF127;" />
-                                            </ToggleMenuFlyoutItem.Icon>
-                                        </ToggleMenuFlyoutItem>
-                                        <ToggleMenuFlyoutItem
-                                            Command="{x:Bind SelectTabThemeCommand}"
-                                            CommandParameter="2"
-                                            IsChecked="{x:Bind TabTheme, Mode=OneWay, Converter={StaticResource TabThemeSelectedConverter}, ConverterParameter=Green}"
-                                            Text="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=TabTheme.Green}">
-                                            <ToggleMenuFlyoutItem.Icon>
-                                                <FontIcon
-                                                    FontFamily="Segoe MDL2 Assets"
-                                                    Foreground="#10893E"
-                                                    Glyph="&#xF127;" />
-                                            </ToggleMenuFlyoutItem.Icon>
-                                        </ToggleMenuFlyoutItem>
-                                        <ToggleMenuFlyoutItem
-                                            Command="{x:Bind SelectTabThemeCommand}"
-                                            CommandParameter="3"
-                                            IsChecked="{x:Bind TabTheme, Mode=OneWay, Converter={StaticResource TabThemeSelectedConverter}, ConverterParameter=Blue}"
-                                            Text="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=TabTheme.Blue}">
-                                            <ToggleMenuFlyoutItem.Icon>
-                                                <FontIcon
-                                                    FontFamily="Segoe MDL2 Assets"
-                                                    Foreground="#0078D7"
-                                                    Glyph="&#xF127;" />
-                                            </ToggleMenuFlyoutItem.Icon>
-                                        </ToggleMenuFlyoutItem>
-                                        <ToggleMenuFlyoutItem
-                                            Command="{x:Bind SelectTabThemeCommand}"
-                                            CommandParameter="4"
-                                            IsChecked="{x:Bind TabTheme, Mode=OneWay, Converter={StaticResource TabThemeSelectedConverter}, ConverterParameter=Purple}"
-                                            Text="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=TabTheme.Purple}">
-                                            <ToggleMenuFlyoutItem.Icon>
-                                                <FontIcon
-                                                    FontFamily="Segoe MDL2 Assets"
-                                                    Foreground="#881798"
-                                                    Glyph="&#xF127;" />
-                                            </ToggleMenuFlyoutItem.Icon>
-                                        </ToggleMenuFlyoutItem>
-                                        <ToggleMenuFlyoutItem
-                                            Command="{x:Bind SelectTabThemeCommand}"
-                                            CommandParameter="5"
-                                            IsChecked="{x:Bind TabTheme, Mode=OneWay, Converter={StaticResource TabThemeSelectedConverter}, ConverterParameter=Orange}"
-                                            Text="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=TabTheme.Orange}">
-                                            <ToggleMenuFlyoutItem.Icon>
-                                                <FontIcon
-                                                    FontFamily="Segoe MDL2 Assets"
-                                                    Foreground="#FF8C00"
-                                                    Glyph="&#xF127;" />
-                                            </ToggleMenuFlyoutItem.Icon>
-                                        </ToggleMenuFlyoutItem>
-                                        <ToggleMenuFlyoutItem
-                                            Command="{x:Bind SelectTabThemeCommand}"
-                                            CommandParameter="6"
-                                            IsChecked="{x:Bind TabTheme, Mode=OneWay, Converter={StaticResource TabThemeSelectedConverter}, ConverterParameter=Teal}"
-                                            Text="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=TabTheme.Teal}">
-                                            <ToggleMenuFlyoutItem.Icon>
-                                                <FontIcon
-                                                    FontFamily="Segoe MDL2 Assets"
-                                                    Foreground="#00B7C3"
-                                                    Glyph="&#xF127;" />
-                                            </ToggleMenuFlyoutItem.Icon>
-                                        </ToggleMenuFlyoutItem>
-                                    </MenuFlyoutSubItem>
-                                    <MenuFlyoutItem x:Uid="EditTitle" Command="{x:Bind EditTitleCommand}" />
-                                    <MenuFlyoutSeparator />
-                                    <MenuFlyoutItem x:Uid="Close" Command="{x:Bind CloseCommand}" />
-                                </MenuFlyout>
-                            </RelativePanel.ContextFlyout>
-                            <Border
-                                Height="3"
-                                VerticalAlignment="Bottom"
-                                Background="{x:Bind TabTheme.Color, Mode=OneWay, Converter={StaticResource ColorResourceKeyFallbackConverter}, ConverterParameter=SystemControlHighlightAccentBrush}"
-                                RelativePanel.AlignBottomWithPanel="True"
-                                RelativePanel.AlignLeftWithPanel="True"
-                                RelativePanel.AlignRightWithPanel="True"
-                                Visibility="{x:Bind IsUnderlined, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}" />
-                            <Grid
-                                x:Name="HasExitedWithError"
+                        <utilities:InteractiveSurface x:Name="InteractiveSurface"
+                                                      Hovered="{x:Bind IsHovered, Mode=TwoWay}">
+                            <RelativePanel
                                 Height="32"
-                                Margin="6,0,0,0"
-                                RelativePanel.AlignLeftWithPanel="True"
-                                Visibility="{x:Bind HasExitedWithError, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}">
-                                <Viewbox
-                                    x:Uid="ExitedWithError"
-                                    Width="12"
-                                    Height="12"
-                                    VerticalAlignment="Center"
-                                    ToolTipService.ToolTip="Exited with error">
-                                    <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE814;" />
-                                </Viewbox>
-                            </Grid>
-                            <TextBlock
-                                Margin="12,8,6,0"
-                                RelativePanel.LeftOf="CloseButton"
-                                RelativePanel.RightOf="HasExitedWithError"
-                                Style="{StaticResource CaptionTextBlockStyle}"
-                                Text="{x:Bind TabTitle, Mode=OneWay}"
-                                TextTrimming="CharacterEllipsis"
-                                TextWrapping="NoWrap" />
-                            <Grid
-                                x:Name="CloseButton"
-                                Width="32"
-                                RelativePanel.AlignRightWithPanel="True">
-                                <Button
-                                    Width="32"
-                                    HorizontalAlignment="Center"
-                                    Command="{x:Bind CloseCommand}"
-                                    Style="{StaticResource TitleBarButtonStyle}"
-                                    ToolTipService.ToolTip="Close"
-                                    Visibility="{x:Bind IsSelected, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}">
-                                    <Viewbox Width="12" Height="12">
-                                        <SymbolIcon Symbol="Cancel" />
-                                    </Viewbox>
-                                </Button>
-                                <Grid Height="32" Visibility="{x:Bind HasNewOutput, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}">
+                                Margin="0"
+                                VerticalAlignment="Stretch"
+                                Background="Transparent"
+                                ToolTipService.ToolTip="{x:Bind TabTitle, Mode=OneWay}">
+
+                                <Interactivity:Interaction.Behaviors>
+                                    <behaviors:MiddleClickBehavior>
+                                        <behaviors:MiddleClickBehavior.Actions>
+                                            <core:InvokeCommandAction Command="{x:Bind CloseCommand}" />
+                                        </behaviors:MiddleClickBehavior.Actions>
+                                    </behaviors:MiddleClickBehavior>
+                                </Interactivity:Interaction.Behaviors>
+
+                                <RelativePanel.ContextFlyout>
+                                    <MenuFlyout>
+                                        <MenuFlyoutSubItem x:Uid="Color">
+                                            <ToggleMenuFlyoutItem
+                                                Command="{x:Bind SelectTabThemeCommand}"
+                                                CommandParameter="0"
+                                                IsChecked="{x:Bind TabTheme, Mode=OneWay, Converter={StaticResource TabThemeSelectedConverter}, ConverterParameter=None}"
+                                                Text="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=TabTheme.None}">
+                                                <ToggleMenuFlyoutItem.Icon>
+                                                    <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xF126;" />
+                                                </ToggleMenuFlyoutItem.Icon>
+                                            </ToggleMenuFlyoutItem>
+                                            <ToggleMenuFlyoutItem
+                                                Command="{x:Bind SelectTabThemeCommand}"
+                                                CommandParameter="1"
+                                                IsChecked="{x:Bind TabTheme, Mode=OneWay, Converter={StaticResource TabThemeSelectedConverter}, ConverterParameter=Red}"
+                                                Text="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=TabTheme.Red}">
+                                                <ToggleMenuFlyoutItem.Icon>
+                                                    <FontIcon
+                                                        FontFamily="Segoe MDL2 Assets"
+                                                        Foreground="#E81123"
+                                                        Glyph="&#xF127;" />
+                                                </ToggleMenuFlyoutItem.Icon>
+                                            </ToggleMenuFlyoutItem>
+                                            <ToggleMenuFlyoutItem
+                                                Command="{x:Bind SelectTabThemeCommand}"
+                                                CommandParameter="2"
+                                                IsChecked="{x:Bind TabTheme, Mode=OneWay, Converter={StaticResource TabThemeSelectedConverter}, ConverterParameter=Green}"
+                                                Text="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=TabTheme.Green}">
+                                                <ToggleMenuFlyoutItem.Icon>
+                                                    <FontIcon
+                                                        FontFamily="Segoe MDL2 Assets"
+                                                        Foreground="#10893E"
+                                                        Glyph="&#xF127;" />
+                                                </ToggleMenuFlyoutItem.Icon>
+                                            </ToggleMenuFlyoutItem>
+                                            <ToggleMenuFlyoutItem
+                                                Command="{x:Bind SelectTabThemeCommand}"
+                                                CommandParameter="3"
+                                                IsChecked="{x:Bind TabTheme, Mode=OneWay, Converter={StaticResource TabThemeSelectedConverter}, ConverterParameter=Blue}"
+                                                Text="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=TabTheme.Blue}">
+                                                <ToggleMenuFlyoutItem.Icon>
+                                                    <FontIcon
+                                                        FontFamily="Segoe MDL2 Assets"
+                                                        Foreground="#0078D7"
+                                                        Glyph="&#xF127;" />
+                                                </ToggleMenuFlyoutItem.Icon>
+                                            </ToggleMenuFlyoutItem>
+                                            <ToggleMenuFlyoutItem
+                                                Command="{x:Bind SelectTabThemeCommand}"
+                                                CommandParameter="4"
+                                                IsChecked="{x:Bind TabTheme, Mode=OneWay, Converter={StaticResource TabThemeSelectedConverter}, ConverterParameter=Purple}"
+                                                Text="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=TabTheme.Purple}">
+                                                <ToggleMenuFlyoutItem.Icon>
+                                                    <FontIcon
+                                                        FontFamily="Segoe MDL2 Assets"
+                                                        Foreground="#881798"
+                                                        Glyph="&#xF127;" />
+                                                </ToggleMenuFlyoutItem.Icon>
+                                            </ToggleMenuFlyoutItem>
+                                            <ToggleMenuFlyoutItem
+                                                Command="{x:Bind SelectTabThemeCommand}"
+                                                CommandParameter="5"
+                                                IsChecked="{x:Bind TabTheme, Mode=OneWay, Converter={StaticResource TabThemeSelectedConverter}, ConverterParameter=Orange}"
+                                                Text="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=TabTheme.Orange}">
+                                                <ToggleMenuFlyoutItem.Icon>
+                                                    <FontIcon
+                                                        FontFamily="Segoe MDL2 Assets"
+                                                        Foreground="#FF8C00"
+                                                        Glyph="&#xF127;" />
+                                                </ToggleMenuFlyoutItem.Icon>
+                                            </ToggleMenuFlyoutItem>
+                                            <ToggleMenuFlyoutItem
+                                                Command="{x:Bind SelectTabThemeCommand}"
+                                                CommandParameter="6"
+                                                IsChecked="{x:Bind TabTheme, Mode=OneWay, Converter={StaticResource TabThemeSelectedConverter}, ConverterParameter=Teal}"
+                                                Text="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=TabTheme.Teal}">
+                                                <ToggleMenuFlyoutItem.Icon>
+                                                    <FontIcon
+                                                        FontFamily="Segoe MDL2 Assets"
+                                                        Foreground="#00B7C3"
+                                                        Glyph="&#xF127;" />
+                                                </ToggleMenuFlyoutItem.Icon>
+                                            </ToggleMenuFlyoutItem>
+                                        </MenuFlyoutSubItem>
+                                        <MenuFlyoutItem x:Uid="EditTitle" Command="{x:Bind EditTitleCommand}" />
+                                        <MenuFlyoutSeparator />
+                                        <MenuFlyoutItem x:Uid="Close" Command="{x:Bind CloseCommand}" />
+                                    </MenuFlyout>
+                                </RelativePanel.ContextFlyout>
+                                <Border
+                                    Height="3"
+                                    VerticalAlignment="Bottom"
+                                    Background="{x:Bind TabTheme.Color, Mode=OneWay, Converter={StaticResource ColorResourceKeyFallbackConverter}, ConverterParameter=SystemControlHighlightAccentBrush}"
+                                    RelativePanel.AlignBottomWithPanel="True"
+                                    RelativePanel.AlignLeftWithPanel="True"
+                                    RelativePanel.AlignRightWithPanel="True"
+                                    Visibility="{x:Bind IsUnderlined, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}" />
+                                <Grid
+                                    x:Name="HasExitedWithError"
+                                    Height="32"
+                                    Margin="6,0,0,0"
+                                    RelativePanel.AlignLeftWithPanel="True"
+                                    Visibility="{x:Bind HasExitedWithError, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}">
                                     <Viewbox
-                                        x:Uid="NewOutput"
+                                        x:Uid="ExitedWithError"
                                         Width="12"
                                         Height="12"
                                         VerticalAlignment="Center"
-                                        ToolTipService.ToolTip="New output">
-                                        <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xEA38;" />
+                                        ToolTipService.ToolTip="Exited with error">
+                                        <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE814;" />
                                     </Viewbox>
                                 </Grid>
-                            </Grid>
-                        </RelativePanel>
+                                <TextBlock
+                                    Margin="12,8,6,0"
+                                    RelativePanel.LeftOf="CloseButton"
+                                    RelativePanel.RightOf="HasExitedWithError"
+                                    Style="{StaticResource CaptionTextBlockStyle}"
+                                    Text="{x:Bind TabTitle, Mode=OneWay}"
+                                    TextTrimming="CharacterEllipsis"
+                                    TextWrapping="NoWrap" />
+                                <Grid
+                                    x:Name="CloseButton"
+                                    Width="32"
+                                    RelativePanel.AlignRightWithPanel="True">
+                                    <Button
+                                        Width="32"
+                                        HorizontalAlignment="Center"
+                                        Command="{x:Bind CloseCommand}"
+                                        Style="{StaticResource TitleBarButtonStyle}"
+                                        ToolTipService.ToolTip="Close"
+                                        Visibility="{x:Bind ShowCloseButton, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}">
+                                        <Viewbox Width="12" Height="12">
+                                            <SymbolIcon Symbol="Cancel" />
+                                        </Viewbox>
+                                    </Button>
+                                    <Grid Height="32" Visibility="{x:Bind HasNewOutput, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}">
+                                        <Viewbox
+                                            x:Uid="NewOutput"
+                                            Width="12"
+                                            Height="12"
+                                            VerticalAlignment="Center"
+                                            ToolTipService.ToolTip="New output">
+                                            <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xEA38;" />
+                                        </Viewbox>
+                                    </Grid>
+                                </Grid>
+                            </RelativePanel>
+                        </utilities:InteractiveSurface>
                     </DataTemplate>
                 </ListView.ItemTemplate>
                 <ListView.ItemContainerStyle>

--- a/FluentTerminal.App/Views/TabBar.xaml
+++ b/FluentTerminal.App/Views/TabBar.xaml
@@ -162,6 +162,9 @@
                                         </MenuFlyoutSubItem>
                                         <MenuFlyoutItem x:Uid="EditTitle" Command="{x:Bind EditTitleCommand}" />
                                         <MenuFlyoutSeparator />
+                                        <MenuFlyoutItem x:Uid="CloseLeft" Command="{x:Bind CloseLeftTabsCommand}" />
+                                        <MenuFlyoutItem x:Uid="CloseRight" Command="{x:Bind CloseRightTabsCommand}" />
+                                        <MenuFlyoutItem x:Uid="CloseOther" Command="{x:Bind CloseOtherTabsCommand}" />
                                         <MenuFlyoutItem x:Uid="Close" Command="{x:Bind CloseCommand}" />
                                     </MenuFlyout>
                                 </RelativePanel.ContextFlyout>


### PR DESCRIPTION
Related to https://github.com/jumptrading/FluentTerminal/issues/160

`class InteractiveSurface : ContentControl` is introduced to wrap ListViewItem template content and provide `Hovered` property.

Also implements https://github.com/jumptrading/FluentTerminal/issues/161

"Close Tabs to the Left", "Close Tabs to the Right", "Close Other Tabs" menu options are added.