### PR TITLE
FIXED: clicking on about in settings does not deselect previous item

### DIFF
--- a/FluentTerminal.App/Views/SettingsPage.xaml
+++ b/FluentTerminal.App/Views/SettingsPage.xaml
@@ -102,6 +102,9 @@
                             ToolTipService.ToolTip="Themes" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
+                <NavigationViewItem
+                    x:Uid="Setting_Hidden" x:Name="Setting_Hidden" Visibility="Collapsed">
+                </NavigationViewItem>                
             </NavigationView.MenuItems>
             <NavigationView.PaneFooter>
                 <NavigationViewItem

--- a/FluentTerminal.App/Views/SettingsPage.xaml.cs
+++ b/FluentTerminal.App/Views/SettingsPage.xaml.cs
@@ -81,13 +81,9 @@ namespace FluentTerminal.App.Views
         {
             _dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
             {
-                ContentFrame.Navigate(typeof(About), ViewModel.About);
-
                 // Deselect item in NavigationView (https://stackoverflow.com/a/49082640/4132379)
-                NavigationView.MenuItems.Add(hiddenNavigationItem);
-                NavigationView.SelectedItem = hiddenNavigationItem;
-                NavigationView.SelectedItem = null;
-                NavigationView.MenuItems.Remove(hiddenNavigationItem);
+                NavigationView.SelectedItem = Setting_Hidden;
+                ContentFrame.Navigate(typeof(About), ViewModel.About);
             });
         }
 


### PR DESCRIPTION
Fixes #465 I reported a few days ago.

Instead of dynamically adding a new item, adding it, setting and unsetting it again, I just add an hidden item that gets selected when about page is displayed.