### PR TITLE
Tab dropping extra space; Preserve drop position.

### DIFF
--- a/FluentTerminal.App.Services/EventArgs/NewTabRequestedEventArgs.cs
+++ b/FluentTerminal.App.Services/EventArgs/NewTabRequestedEventArgs.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using Windows.UI.Xaml;
+
+namespace FluentTerminal.App.Services.EventArgs
+{
+    public class NewTabRequestedEventArgs : System.EventArgs
+    {
+        public DragEventArgs DragEventArgs { get; set; }
+        public int Position { get; set; }
+    }
+}

--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -341,7 +341,7 @@ namespace FluentTerminal.App.ViewModels
             }
         }
 
-        public Task AddTerminalAsync(ShellProfile profile, string terminalState)
+        public Task AddTerminalAsync(ShellProfile profile, string terminalState, int position)
         {
             return ApplicationView.RunOnDispatcherThread(() =>
             {
@@ -351,7 +351,7 @@ namespace FluentTerminal.App.ViewModels
                 terminal.Closed += OnTerminalClosed;
                 terminal.ShellTitleChanged += Terminal_ShellTitleChanged;
                 terminal.CustomTitleChanged += Terminal_CustomTitleChanged;
-                Terminals.Add(terminal);
+                Terminals.Insert(position, terminal);
 
                 SelectedTerminal = terminal;
             });
@@ -359,12 +359,12 @@ namespace FluentTerminal.App.ViewModels
 
         public Task AddTerminalAsync(ShellProfile profile)
         {
-            return AddTerminalAsync(profile, "");
+            return AddTerminalAsync(profile, "", Terminals.Count);
         }
 
-        public Task AddTerminalAsync(string terminalState)
+        public Task AddTerminalAsync(string terminalState, int position)
         {
-            return AddTerminalAsync(new ShellProfile(), terminalState);
+            return AddTerminalAsync(new ShellProfile(), terminalState, position);
         }
 
         private void Terminal_CustomTitleChanged(object sender, string e)

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -608,7 +608,7 @@ namespace FluentTerminal.App
             Logger.Instance.Debug("App.xaml.cs on tab tear off");
 
             var newViewModel = await CreateNewTerminalWindow().ConfigureAwait(true);
-            await newViewModel.AddTerminalAsync(await model.Serialize());
+            await newViewModel.AddTerminalAsync(await model.Serialize(), 0);
         }
 
         private async void OnNewWindowRequested(object sender, NewWindowRequestedEventArgs e)

--- a/FluentTerminal.App/Strings/en/Resources.resw
+++ b/FluentTerminal.App/Strings/en/Resources.resw
@@ -977,4 +977,8 @@ Fuzzy</comment>
   <data name="InvalidLink" xml:space="preserve">
     <value>Invalid link.</value>
   </data>
+  <data name="DropTabHere" xml:space="preserve">
+    <value>Drop tab here</value>
+    <comment>Drop hint</comment>
+  </data>
 </root>

--- a/FluentTerminal.App/Views/MainPage.xaml
+++ b/FluentTerminal.App/Views/MainPage.xaml
@@ -188,7 +188,13 @@
                     TextWrapping="NoWrap"
                     Visibility="{x:Bind ViewModel.ShowTabsOnTop, Mode=OneWay, Converter={StaticResource FalseToVisibleConverter}}" />
             </RelativePanel>
+            <Rectangle x:Name="TabDropArea" Fill="LightGray" Opacity="0.2" Grid.Column="1" HorizontalAlignment="Stretch"
+                       AllowDrop="True"
+                       DragEnter="TabDropArea_DragEnter"
+                       Drop="TabDropArea_Drop"
+                       Visibility="{x:Bind DraggingHappens, Mode=TwoWay, Converter={StaticResource TrueToVisibleConverter}}"/>
             <views:TabBar
+                x:Name="TopTabBar"
                 Grid.Column="1"
                 HorizontalAlignment="Left"
                 AddCommand="{x:Bind ViewModel.AddLocalShellCommand}"
@@ -197,7 +203,8 @@
                 Visibility="{x:Bind ViewModel.ShowTabsOnTop, Mode=OneWay}"
                 TabDraggedOutside="TabBar_TabDraggedOutside"
                 TabWindowChanged="TabView_Drop"
-                TabDraggingCompleted="TabBar_TabDraggingCompleted" />
+                TabDraggingCompleted="TabBar_TabDraggingCompleted"
+                TabDraggingChanged="TabBar_TabDraggingChanged" />
         </Grid>
         <ContentControl
             x:Name="TerminalContainer"
@@ -205,7 +212,13 @@
             HorizontalContentAlignment="Stretch"
             VerticalContentAlignment="Stretch"
             Content="{x:Bind ViewModel.SelectedTerminal, Mode=OneWay, Converter={StaticResource TerminalViewModelToViewConverter}}" />
+        <Rectangle Fill="LightGray" Opacity="0.2" Grid.Row="2" HorizontalAlignment="Stretch"
+                       AllowDrop="True"
+                       DragEnter="TabDropArea_DragEnter"
+                       Drop="TabDropArea_Drop"
+                       Visibility="{x:Bind DraggingHappens, Mode=TwoWay, Converter={StaticResource TrueToVisibleConverter}}"/>
         <views:TabBar
+            x:Name="BottomTabBar"
             Grid.Row="2"
             HorizontalAlignment="Left"
             AddCommand="{x:Bind ViewModel.AddLocalShellCommand}"
@@ -214,6 +227,7 @@
             Visibility="{x:Bind ViewModel.ShowTabsOnBottom, Mode=OneWay}"
             TabDraggedOutside="TabBar_TabDraggedOutside"
             TabWindowChanged="TabView_Drop"
-            TabDraggingCompleted="TabBar_TabDraggingCompleted" />
+            TabDraggingCompleted="TabBar_TabDraggingCompleted"
+            TabDraggingChanged="TabBar_TabDraggingChanged" />
     </Grid>
 </Page>

--- a/FluentTerminal.App/Views/MainPage.xaml.cs
+++ b/FluentTerminal.App/Views/MainPage.xaml.cs
@@ -10,6 +10,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 using FluentTerminal.App.Services;
+using FluentTerminal.App.Services.EventArgs;
 
 namespace FluentTerminal.App.Views
 {
@@ -98,11 +99,11 @@ namespace FluentTerminal.App.Views
             }
         }
 
-        private async void TabView_Drop(object sender, DragEventArgs e)
+        private async void TabView_Drop(object sender, NewTabRequestedEventArgs e)
         {
-            if (e.DataView.Properties.TryGetValue(Constants.TerminalViewModelStateId, out object stateObj) && stateObj is string terminalViewModelState)
+            if (e.DragEventArgs.DataView.Properties.TryGetValue(Constants.TerminalViewModelStateId, out object stateObj) && stateObj is string terminalViewModelState)
             {
-                await ViewModel.AddTerminalAsync(terminalViewModelState);
+                await ViewModel.AddTerminalAsync(terminalViewModelState, e.Position);
             }
         }
 


### PR DESCRIPTION
Supersedes https://github.com/felixse/FluentTerminal/pull/475

Implements:

- Extended tab drop landing area visible only on dragging (appears NOT in drag source window)

- On tab drop to another window it calculates position for moved tab and inserts "restored" TerminalViewModel to calculated position.