### PR TITLE
Ensure processes are killed for ConPTY sessions

### DIFF
--- a/FluentTerminal.SystemTray/FluentTerminal.SystemTray.csproj
+++ b/FluentTerminal.SystemTray/FluentTerminal.SystemTray.csproj
@@ -79,6 +79,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Runtime.InteropServices.WindowsRuntime" />
     <Reference Include="System.Runtime.WindowsRuntime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -113,6 +114,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ProcessUtils.cs" />
     <Compile Include="FileFinder.cs" />
     <Compile Include="Native\ProcessApi.cs" />
     <Compile Include="Native\WindowApi.cs" />

--- a/FluentTerminal.SystemTray/ProcessUtils.cs
+++ b/FluentTerminal.SystemTray/ProcessUtils.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Management;
+
+using FluentTerminal.App.Services;
+
+namespace FluentTerminal.SystemTray
+{
+    public static class ProcessUtils
+    {
+        /// <summary>
+        /// Kill a process, and all of its children, grandchildren, etc.
+        /// </summary>
+        /// <param name="pid">Process ID.</param>
+        public static void KillTree(int pid)
+        {
+            var searcher = new ManagementObjectSearcher("Select * From Win32_Process Where ParentProcessID=" + pid);
+            foreach (ManagementObject mo in searcher.Get())
+            {
+                KillTree(Convert.ToInt32(mo["ProcessID"]));
+            }
+
+            try
+            {
+                Process.GetProcessById(pid).Kill();
+            }
+            catch (ArgumentException)
+            {
+                // Process already exited.
+            }
+        }
+    }
+}

--- a/FluentTerminal.SystemTray/Services/ConPty/PseudoConsole.cs
+++ b/FluentTerminal.SystemTray/Services/ConPty/PseudoConsole.cs
@@ -19,6 +19,11 @@ namespace FluentTerminal.SystemTray.Services.ConPty
             Handle = handle;
         }
 
+        ~PseudoConsole()
+        {
+            Dispose();
+        }
+
         internal static PseudoConsole Create(SafeFileHandle inputReadSide, SafeFileHandle outputWriteSide, int width, int height)
         {
             var createResult = CreatePseudoConsole(
@@ -40,6 +45,7 @@ namespace FluentTerminal.SystemTray.Services.ConPty
         public void Dispose()
         {
             ClosePseudoConsole(Handle);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/FluentTerminal.SystemTray/Services/ConPty/PseudoConsolePipe.cs
+++ b/FluentTerminal.SystemTray/Services/ConPty/PseudoConsolePipe.cs
@@ -26,7 +26,18 @@ namespace FluentTerminal.SystemTray.Services.ConPty
             }
         }
 
+        ~PseudoConsolePipe()
+        {
+            Dispose(false);
+        }
+
         #region IDisposable
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
 
         void Dispose(bool disposing)
         {
@@ -35,12 +46,6 @@ namespace FluentTerminal.SystemTray.Services.ConPty
                 ReadSide?.Dispose();
                 WriteSide?.Dispose();
             }
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
         }
 
         #endregion

--- a/FluentTerminal.SystemTray/Services/TerminalsManager.cs
+++ b/FluentTerminal.SystemTray/Services/TerminalsManager.cs
@@ -217,8 +217,8 @@ namespace FluentTerminal.SystemTray.Services
             if (sender is ITerminalSession terminal)
             {
                 _terminals.Remove(terminal.Id);
-                terminal.Dispose();
                 TerminalExited?.Invoke(this, new TerminalExitStatus(terminal.Id, exitcode));
+                terminal.Dispose();
             }
         }
     }

--- a/FluentTerminal.SystemTray/Services/WinPty/WinPtySession.cs
+++ b/FluentTerminal.SystemTray/Services/WinPty/WinPtySession.cs
@@ -100,8 +100,6 @@ namespace FluentTerminal.SystemTray.Services.WinPty
             Dispose(false);
         }
 
-        
-
         private string GetWorkingDirectory(ShellProfile configuration)
         {
             if (string.IsNullOrWhiteSpace(configuration.WorkingDirectory) || !Directory.Exists(configuration.WorkingDirectory))


### PR DESCRIPTION
- Clarified Dispose logic for ConPTY Terminal and Process
- Disposing a ConPTY Process now kills it and its children
- ConPTY Terminal now cleans up everything in its Dispose
- Wired up missing Dispose calls in various finalizers
- Removed ConPTY CTRL_CLOSE_EVENT handling. This event never seems to actually happen and the Terminal should get cleaned up eventually anyway.

Fixes https://github.com/jumptrading/FluentTerminal/issues/94