### PR TITLE
Do not send pointer events to WebView while dragging of tab happens.

### DIFF
--- a/FluentTerminal.App/Views/MainPage.xaml
+++ b/FluentTerminal.App/Views/MainPage.xaml
@@ -192,7 +192,7 @@
                        AllowDrop="True"
                        DragEnter="TabDropArea_DragEnter"
                        Drop="TabDropArea_Drop"
-                       Visibility="{x:Bind DraggingHappens, Mode=TwoWay, Converter={StaticResource TrueToVisibleConverter}}"/>
+                       Visibility="{x:Bind DraggingHappensFromAnotherWindow, Mode=TwoWay, Converter={StaticResource TrueToVisibleConverter}}"/>
             <views:TabBar
                 x:Name="TopTabBar"
                 Grid.Column="1"
@@ -212,11 +212,13 @@
             HorizontalContentAlignment="Stretch"
             VerticalContentAlignment="Stretch"
             Content="{x:Bind ViewModel.SelectedTerminal, Mode=OneWay, Converter={StaticResource TerminalViewModelToViewConverter}}" />
+        <Rectangle Fill="LightGray" Opacity="0.01" Grid.Row="1"
+                       Visibility="{x:Bind DraggingHappens, Mode=TwoWay, Converter={StaticResource TrueToVisibleConverter}}"/>
         <Rectangle Fill="LightGray" Opacity="0.2" Grid.Row="2" HorizontalAlignment="Stretch"
                        AllowDrop="True"
                        DragEnter="TabDropArea_DragEnter"
                        Drop="TabDropArea_Drop"
-                       Visibility="{x:Bind DraggingHappens, Mode=TwoWay, Converter={StaticResource TrueToVisibleConverter}}"/>
+                       Visibility="{x:Bind DraggingHappensFromAnotherWindow, Mode=TwoWay, Converter={StaticResource TrueToVisibleConverter}}"/>
         <views:TabBar
             x:Name="BottomTabBar"
             Grid.Row="2"

--- a/FluentTerminal.App/Views/MainPage.xaml.cs
+++ b/FluentTerminal.App/Views/MainPage.xaml.cs
@@ -63,14 +63,15 @@ namespace FluentTerminal.App.Views
 
         private async void MainPage_DraggingHappensChanged(object sender, bool e)
         {
-            if (sender != TopTabBar && sender != BottomTabBar)
+            await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
             {
-                await Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+                if (sender != TopTabBar && sender != BottomTabBar)
                 {
-                    DraggingHappens = e;
-                });
-            }
-        }
+                    DraggingHappensFromAnotherWindow = e;
+                }
+                DraggingHappens = e;
+            });
+         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
@@ -145,8 +146,17 @@ namespace FluentTerminal.App.Views
             }
         }
 
+        public static readonly DependencyProperty DraggingHappensFromAnotherWindowProperty =
+            DependencyProperty.Register(nameof(DraggingHappensFromAnotherWindow), typeof(bool), typeof(MainPage), new PropertyMetadata(null));
+
+        public bool DraggingHappensFromAnotherWindow
+        {
+            get { return (bool)GetValue(DraggingHappensFromAnotherWindowProperty); }
+            set { SetValue(DraggingHappensFromAnotherWindowProperty, value); }
+        }
+
         public static readonly DependencyProperty DraggingHappensProperty =
-    DependencyProperty.Register(nameof(DraggingHappens), typeof(bool), typeof(MainPage), new PropertyMetadata(null));
+            DependencyProperty.Register(nameof(DraggingHappens), typeof(bool), typeof(MainPage), new PropertyMetadata(null));
 
         public bool DraggingHappens
         {


### PR DESCRIPTION
Related to https://github.com/jumptrading/FluentTerminal/issues/165

Issue's description:

If the mouse goes over an active terminal window while a tab is being dragged, events are sent to that terminal causing it to scroll. This is unexpected and almost certainly not what you want.

Proposed solution background:

Scrolling, seems, happens because of [overflow-y: scroll](https://github.com/xtermjs/xterm.js/blob/master/css/xterm.css#L96). Pointer hovering with pressed mouse button in front of scroll bar edges causes not desired scrolling. `scroll` value can be changed to 'hidden' to remove scrolling, but in that case scroll bar control will not be rendered by WebView if scrollbar visibility is set to "always" in Fluent Settings.

Since solving of the issue directly in JavaScript looks too complex, it makes sense to do it from C# side. But WebView control "eats" all pointer events, it also can't be inherited to redefine events handling and officially suggested way to customize pointer events behavior for WebView is to send them back to C# from JavaScript.

Proposed changelist shows transparent rectangle on top of WebView to suppress pointer events propagation. Events blocking happens while user drags a tab.