### PR TITLE
Resolve GC's disposal issues.

### DIFF
--- a/FluentTerminal.App.Services/ITrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/ITrayProcessCommunicationService.cs
@@ -24,6 +24,8 @@ namespace FluentTerminal.App.Services
 
         void SubscribeForTerminalOutput(byte terminalId, Action<byte[]> callback);
 
+        void UnsubscribeFromTerminalOutput(byte terminalId);
+
         Task CloseTerminal(byte terminalId);
         Task<GetAvailablePortResponse> GetAvailablePort();
         byte GetNextTerminalId();

--- a/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
@@ -233,6 +233,14 @@ namespace FluentTerminal.App.Services.Implementation
             _terminalOutputHandlers[terminalId] = callback;
         }
 
+        public void UnsubscribeFromTerminalOutput(byte terminalId)
+        {
+            if (_terminalOutputHandlers.ContainsKey(terminalId))
+            {
+                _terminalOutputHandlers.Remove(terminalId);
+            }
+        }
+
         public Task UpdateToggleWindowKeyBindings()
         {
             var keyBindings = _settingsService.GetCommandKeyBindings()[nameof(Command.ToggleWindow)];

--- a/FluentTerminal.App.Services/Terminal.cs
+++ b/FluentTerminal.App.Services/Terminal.cs
@@ -37,6 +37,8 @@ namespace FluentTerminal.App.Services
             {
                 Closed?.Invoke(this, System.EventArgs.Empty);
             }
+
+            _trayProcessCommunicationService.TerminalExited -= OnTerminalExited;
         }
 
         public event EventHandler<int> Exited;
@@ -81,6 +83,7 @@ namespace FluentTerminal.App.Services
                 return;
             }
             _closingFromUI = true;
+            _trayProcessCommunicationService.UnsubscribeFromTerminalOutput(Id);
             await _trayProcessCommunicationService.CloseTerminal(Id).ConfigureAwait(true);
         }
 

--- a/FluentTerminal.App.ViewModels/ITerminalView.cs
+++ b/FluentTerminal.App.ViewModels/ITerminalView.cs
@@ -9,6 +9,7 @@ namespace FluentTerminal.App.ViewModels
         Task ChangeKeyBindings();
         Task ChangeOptions(TerminalOptions options);
         Task Initialize(TerminalViewModel viewModel);
+        void DisposalPrepare();
         Task FindNext(string searchText);
         Task FindPrevious(string searchText);
         Task FocusTerminal();

--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -454,6 +454,10 @@ namespace FluentTerminal.App.ViewModels
                 terminal.Closed -= OnTerminalClosed;
                 terminal.ShellTitleChanged -= Terminal_ShellTitleChanged;
                 terminal.CustomTitleChanged -= Terminal_CustomTitleChanged;
+                terminal.CloseLeftTabsRequested -= Terminal_CloseLeftTabsRequested;
+                terminal.CloseRightTabsRequested -= Terminal_CloseRightTabsRequested;
+                terminal.CloseOtherTabsRequested -= Terminal_CloseOtherTabsRequested;
+                terminal.DuplicateTabRequested -= Terminal_DuplicateTabRequested;
                 await terminal.Close();
             }
         }
@@ -537,6 +541,15 @@ namespace FluentTerminal.App.ViewModels
                     SelectedTerminal = Terminals.LastOrDefault(t => t != terminal);
                 }
                 Logger.Instance.Debug("Terminal with Id: {@id} closed.", terminal.Terminal.Id);
+
+                terminal.Closed -= OnTerminalClosed;
+                terminal.ShellTitleChanged -= Terminal_ShellTitleChanged;
+                terminal.CustomTitleChanged -= Terminal_CustomTitleChanged;
+                terminal.CloseLeftTabsRequested -= Terminal_CloseLeftTabsRequested;
+                terminal.CloseRightTabsRequested -= Terminal_CloseRightTabsRequested;
+                terminal.CloseOtherTabsRequested -= Terminal_CloseOtherTabsRequested;
+                terminal.DuplicateTabRequested -= Terminal_DuplicateTabRequested;
+
                 Terminals.Remove(terminal);
 
                 if (Terminals.Count == 0)

--- a/FluentTerminal.App.ViewModels/OverlayViewModel.cs
+++ b/FluentTerminal.App.ViewModels/OverlayViewModel.cs
@@ -14,7 +14,6 @@ namespace FluentTerminal.App.ViewModels
         {
             _overlayTimer = dispatcherTimer;
             _overlayTimer.Interval = new TimeSpan(0, 0, 2);
-            _overlayTimer.Tick += OnResizeOverlayTimerFinished;
         }
 
         public bool ShowOverlay
@@ -37,13 +36,16 @@ namespace FluentTerminal.App.ViewModels
             if (_overlayTimer.IsEnabled)
             {
                 _overlayTimer.Stop();
+                _overlayTimer.Tick -= OnResizeOverlayTimerFinished;
             }
             _overlayTimer.Start();
+            _overlayTimer.Tick += OnResizeOverlayTimerFinished;
         }
 
         private void OnResizeOverlayTimerFinished(object sender, object e)
         {
             _overlayTimer.Stop();
+            _overlayTimer.Tick -= OnResizeOverlayTimerFinished;
             ShowOverlay = false;
         }
 

--- a/FluentTerminal.App.ViewModels/TerminalViewModel.cs
+++ b/FluentTerminal.App.ViewModels/TerminalViewModel.cs
@@ -146,6 +146,14 @@ namespace FluentTerminal.App.ViewModels
 
         }
 
+        public void DisposalPrepare()
+        {
+            TerminalView.DisposalPrepare();
+            TerminalView = null;
+            Terminal = null;
+            Overlay = null;
+        }
+
         public event EventHandler Activated;
         public event EventHandler Closed;
         public event EventHandler<string> FindNextRequested;
@@ -476,6 +484,13 @@ namespace FluentTerminal.App.ViewModels
         private void Terminal_Closed(object sender, EventArgs e)
         {
             ApplicationView.RunOnDispatcherThread(() => Closed?.Invoke(this, EventArgs.Empty));
+
+            Terminal.KeyboardCommandReceived -= Terminal_KeyboardCommandReceived;
+            Terminal.OutputReceived -= Terminal_OutputReceived;
+            Terminal.SizeChanged -= Terminal_SizeChanged;
+            Terminal.TitleChanged -= Terminal_TitleChanged;
+            Terminal.Exited -= Terminal_Exited;
+            Terminal.Closed -= Terminal_Closed;
         }
 
         private async void Terminal_KeyboardCommandReceived(object sender, string e)

--- a/FluentTerminal.App/Adapters/DispatcherTimerAdapter.cs
+++ b/FluentTerminal.App/Adapters/DispatcherTimerAdapter.cs
@@ -11,7 +11,6 @@ namespace FluentTerminal.App.Adapters
         public DispatcherTimerAdapter()
         {
             _dispatcherTimer = new DispatcherTimer();
-            _dispatcherTimer.Tick += OnDispatcherTimerTick;
         }
 
         private void OnDispatcherTimerTick(object sender, object e)
@@ -31,12 +30,14 @@ namespace FluentTerminal.App.Adapters
 
         public void Start()
         {
+            _dispatcherTimer.Tick += OnDispatcherTimerTick;
             _dispatcherTimer.Start();
         }
 
         public void Stop()
         {
             _dispatcherTimer.Stop();
+            _dispatcherTimer.Tick -= OnDispatcherTimerTick;
         }
     }
 }

--- a/FluentTerminal.App/Converters/TerminalViewModelToViewConverter.cs
+++ b/FluentTerminal.App/Converters/TerminalViewModelToViewConverter.cs
@@ -15,6 +15,16 @@ namespace FluentTerminal.App.Converters
             _viewDictionary = new Dictionary<TerminalViewModel, TerminalView>();
         }
 
+        public void RemoveTerminal(TerminalViewModel viewModel)
+        {
+            if (_viewDictionary.TryGetValue(viewModel, out TerminalView terminalView))
+            {
+                viewModel.DisposalPrepare();
+                terminalView.DisposalPrepare();
+            }
+            _viewDictionary.Remove(viewModel);
+        }
+
         public object Convert(object value, Type targetType, object parameter, string language)
         {
             if (value is TerminalViewModel terminal)

--- a/FluentTerminal.App/Views/TerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/TerminalView.xaml.cs
@@ -27,7 +27,23 @@ namespace FluentTerminal.App.Views
             ViewModel.TerminalView = _terminalView;
         }
 
-        public TerminalViewModel ViewModel { get; }
+        public void DisposalPrepare()
+        {
+            Bindings.StopTracking();
+            TerminalContainer.Children.Remove((UIElement)_terminalView);
+
+            ViewModel.SearchStarted -= OnSearchStarted;
+            ViewModel.Activated -= OnActivated;
+            ViewModel.ThemeChanged -= OnThemeChanged;
+            ViewModel.OptionsChanged -= OnOptionsChanged;
+            ViewModel.KeyBindingsChanged -= OnKeyBindingsChanged;
+            ViewModel.FindNextRequested -= OnFindNextRequested;
+            ViewModel.FindPreviousRequested -= OnFindPreviousRequested;
+
+            ViewModel = null;
+        }
+
+        public TerminalViewModel ViewModel { get; private set; }
 
         private async void OnActivated(object sender, EventArgs e)
         {

--- a/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Fleck;
+using FluentTerminal.App.Converters;
 using FluentTerminal.App.Services;
 using FluentTerminal.App.Services.Utilities;
 using FluentTerminal.App.Utilities;
@@ -40,6 +41,8 @@ namespace FluentTerminal.App.Views
         private WebView _webView;
         private readonly DebouncedAction<TerminalOptions> _optionsChanged;
         private IWebSocketConnection _socket;
+        private WebSocketServer _webSocketServer;
+        private CancellationTokenSource _mediatorTaskCTSource;
 
         // Members related to resize handling
         private readonly DebouncedAction<TerminalSize> _sizeChanged;
@@ -193,6 +196,11 @@ namespace FluentTerminal.App.Views
             _webView.Focus(FocusState.Programmatic);
         }
 
+        public void DisposalPrepare()
+        {
+            ViewModel = null;
+        }
+
         void IxtermEventListener.OnKeyboardCommand(string command)
         {
             Logger.Instance.Debug("Received keyboard command: '{command}'", command);
@@ -305,21 +313,28 @@ namespace FluentTerminal.App.Views
             };
 
             var webSocketUrl = "ws://127.0.0.1:" + port;
-            var webSocketServer = new WebSocketServer(webSocketUrl);
-            webSocketServer.Start(socket =>
+            _webSocketServer = new WebSocketServer(webSocketUrl);
+            _webSocketServer.Start(socket =>
             {
                 _socket = socket;
-                socket.OnOpen = () =>
-                {
-                    Logger.Instance.Debug("WebSocket open");
-                    _connectedEvent.Set();
-                };
-                socket.OnMessage = message => ViewModel.Terminal.Write(Encoding.UTF8.GetBytes(message));
+                _socket.OnOpen += OnWebSocketOpened;
+                _socket.OnMessage += OnWebSocketMessage;
             });
 
             Logger.Instance.Debug("WebSocketServer started. Calling connectToWebSocket() now.");
 
             await ExecuteScriptAsync($"connectToWebSocket('{webSocketUrl}');").ConfigureAwait(true);
+        }
+
+        private void OnWebSocketMessage(string message)
+        {
+            ViewModel.Terminal.Write(Encoding.UTF8.GetBytes(message));
+        }
+
+        private void OnWebSocketOpened()
+        {
+            Logger.Instance.Debug("WebSocket open");
+            _connectedEvent.Set();
         }
 
         private async Task<TerminalSize> CreateXtermView(TerminalOptions options, TerminalColors theme, IEnumerable<KeyBinding> keyBindings)
@@ -365,19 +380,26 @@ namespace FluentTerminal.App.Views
         {
             _dispatcherJobs = new BlockingCollection<Action>();
             var dispatcher = CoreApplication.GetCurrentView().CoreWindow.Dispatcher;
+            _mediatorTaskCTSource = new CancellationTokenSource();
             Task.Factory.StartNew(async () =>
             {
-                foreach (var job in _dispatcherJobs.GetConsumingEnumerable())
+                try
                 {
-                    try
+                    _mediatorTaskCTSource.Token.ThrowIfCancellationRequested();
+                    foreach (var job in _dispatcherJobs.GetConsumingEnumerable(_mediatorTaskCTSource.Token))
                     {
-                        await dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => job.Invoke());
-                    }
-                    catch (Exception e)
-                    {
-                        Debug.WriteLine(e);
+                        _mediatorTaskCTSource.Token.ThrowIfCancellationRequested();
+                        try
+                        {
+                            await dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => job.Invoke());
+                        }
+                        catch (Exception e)
+                        {
+                            Debug.WriteLine(e);
+                        }
                     }
                 }
+                catch (OperationCanceledException) { }
             }, TaskCreationOptions.LongRunning);
         }
 
@@ -385,10 +407,33 @@ namespace FluentTerminal.App.Views
         {
             await ViewModel.ApplicationView.RunOnDispatcherThread(() =>
             {
+                _webView.NavigationCompleted -= _webView_NavigationCompleted;
+                _webView.NavigationStarting -= _webView_NavigationStarting;
                 ViewModel.Terminal.OutputReceived -= Terminal_OutputReceived;
                 ViewModel.Terminal.Closed -= Terminal_Closed;
                 _webView?.Navigate(new Uri("about:blank"));
+                Root.Children.Remove(_webView);
                 _webView = null;
+
+                _socket.OnOpen -= OnWebSocketOpened;
+                _socket.OnMessage -= OnWebSocketMessage;
+                _socket.Close();
+                FleckLog.LogAction = null;
+                _webSocketServer.Dispose();
+                _webSocketServer = null;
+                _socket = null;
+
+                _copyMenuItem.Click -= Copy_Click;
+                _pasteMenuItem.Click -= Paste_Click;
+                _mediatorTaskCTSource.Cancel();
+
+                if (Window.Current.Content is Frame frame && frame.Content is Page mainPage)
+                {
+                    if (mainPage.Resources["TerminalViewModelToViewConverter"] is TerminalViewModelToViewConverter converter)
+                    {
+                        converter.RemoveTerminal(ViewModel);
+                    }
+                }
             });
         }
 


### PR DESCRIPTION
There are a bunch of things prevented GC from objects trashing:

- Keeping object references in collections without after usage removal ( `TrayProcessCommunicationService._terminalOutputHandlers` and `TerminalViewModelToViewConverter._viewDictionary` ).

- Not unsubscribed events.

- Strong references to methods used in `DebouncedAction`.

- Missed disposing of `WebSocketServer` instance and connection closing.

- Infinite background task running from `XTermTerminalView.StartMediatorTask`

- Manually added UI elements to a visual tree are not removed automatically

- Exposing ViewModel references to XAML creates strong refs