### PR TITLE
Extend list of word separators for text selection.

### DIFF
--- a/FluentTerminal.Client/src/index.ts
+++ b/FluentTerminal.Client/src/index.ts
@@ -58,7 +58,7 @@ window.createTerminal = (options, theme, keyBindings) => {
     allowTransparency: true,
     theme: theme,
     windowsMode: true,
-    wordSeparator: ' ()[]{}\'":;'
+    wordSeparator: ' ()[]{}\'":;|│!&*<>@'
   };
 
   term = new Terminal(terminalOptions);


### PR DESCRIPTION
Related to discussion https://github.com/jumptrading/FluentTerminal/issues/106

Also adds `tmux` vertical pane border character.