### PR TITLE
Crash on close; Resizing leads to freezed terminals.

### DIFF
--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -375,17 +375,17 @@ namespace FluentTerminal.App.ViewModels
             if (sender is TerminalViewModel terminal)
             {
                 Array.ForEach<TerminalViewModel>(Terminals.ToArray(),
-                    t => {
+                    async t => {
                         if (terminal != t)
                         {
                             Logger.Instance.Debug("Terminal with Id: {@id} closed.", t.Terminal.Id);
-                            t.CloseCommand.Execute(EventArgs.Empty);
+                            await t.CloseCommand.ExecuteAsync();
                         }
                     });
             }
         }
 
-        private void Terminal_CloseRightTabsRequested(object sender, EventArgs e)
+        private async void Terminal_CloseRightTabsRequested(object sender, EventArgs e)
         {
             if (sender is TerminalViewModel terminal)
             {
@@ -393,12 +393,12 @@ namespace FluentTerminal.App.ViewModels
                 {
                     var terminalToRemove = Terminals[i];
                     Logger.Instance.Debug("Terminal with Id: {@id} closed.", terminalToRemove.Terminal.Id);
-                    terminalToRemove.CloseCommand.Execute(EventArgs.Empty);
+                    await terminalToRemove.CloseCommand.ExecuteAsync();
                 }
             }
         }
 
-        private void Terminal_CloseLeftTabsRequested(object sender, EventArgs e)
+        private async void Terminal_CloseLeftTabsRequested(object sender, EventArgs e)
         {
             if (sender is TerminalViewModel terminal)
             {
@@ -406,7 +406,7 @@ namespace FluentTerminal.App.ViewModels
                 {
                     var terminalToRemove = Terminals[i];
                     Logger.Instance.Debug("Terminal with Id: {@id} closed.", terminalToRemove.Terminal.Id);
-                    terminalToRemove.CloseCommand.Execute(EventArgs.Empty);
+                    await terminalToRemove.CloseCommand.ExecuteAsync();
                 }
             }
         }
@@ -464,7 +464,7 @@ namespace FluentTerminal.App.ViewModels
 
         private void CloseCurrentTab()
         {
-            SelectedTerminal?.CloseCommand.Execute(null);
+            SelectedTerminal?.CloseCommand.ExecuteAsync();
         }
 
         private void NewWindow(NewWindowAction showSelection)

--- a/FluentTerminal.App.ViewModels/TerminalViewModel.cs
+++ b/FluentTerminal.App.ViewModels/TerminalViewModel.cs
@@ -118,7 +118,7 @@ namespace FluentTerminal.App.ViewModels
             TabThemes = new ObservableCollection<TabTheme>(SettingsService.GetTabThemes());
             TabTheme = TabThemes.FirstOrDefault(t => t.Id == ShellProfile.TabThemeId);
 
-            CloseCommand = new RelayCommand(CloseTab, CanExecuteCommand);
+            CloseCommand = new AsyncCommand(CloseTab, CanExecuteCommand);
             CloseLeftTabsCommand = new RelayCommand(CloseLeftTabs, CanExecuteCommand);
             CloseRightTabsCommand = new RelayCommand(CloseRightTabs, CanExecuteCommand);
             CloseOtherTabsCommand = new RelayCommand(CloseOtherTabs, CanExecuteCommand);
@@ -190,7 +190,7 @@ namespace FluentTerminal.App.ViewModels
 
         public string XtermBufferState { get; private set; }
 
-        public RelayCommand CloseCommand { get; private set; }
+        public AsyncCommand CloseCommand { get; private set; }
 
         public RelayCommand CloseRightTabsCommand { get; }
 
@@ -410,7 +410,7 @@ namespace FluentTerminal.App.ViewModels
             return (Initialized == true && _disposalRequested == false);
         }
 
-        private async void CloseTab()
+        private async Task CloseTab()
         {
              await TryClose().ConfigureAwait(false);
         }

--- a/FluentTerminal.App.ViewModels/TerminalViewModel.cs
+++ b/FluentTerminal.App.ViewModels/TerminalViewModel.cs
@@ -118,16 +118,16 @@ namespace FluentTerminal.App.ViewModels
             TabThemes = new ObservableCollection<TabTheme>(SettingsService.GetTabThemes());
             TabTheme = TabThemes.FirstOrDefault(t => t.Id == ShellProfile.TabThemeId);
 
-            CloseCommand = new RelayCommand(async () => await TryClose().ConfigureAwait(false));
-            CloseLeftTabsCommand = new RelayCommand(CloseLeftTabs);
-            CloseRightTabsCommand = new RelayCommand(CloseRightTabs);
-            CloseOtherTabsCommand = new RelayCommand(CloseOtherTabs);
-            FindNextCommand = new RelayCommand(FindNext);
-            FindPreviousCommand = new RelayCommand(FindPrevious);
-            CloseSearchPanelCommand = new RelayCommand(CloseSearchPanel);
-            SelectTabThemeCommand = new RelayCommand<string>(SelectTabTheme);
-            EditTitleCommand = new AsyncCommand(EditTitle);
-            DuplicateTabCommand = new RelayCommand(DuplicateTab);
+            CloseCommand = new RelayCommand(CloseTab, CanExecuteCommand);
+            CloseLeftTabsCommand = new RelayCommand(CloseLeftTabs, CanExecuteCommand);
+            CloseRightTabsCommand = new RelayCommand(CloseRightTabs, CanExecuteCommand);
+            CloseOtherTabsCommand = new RelayCommand(CloseOtherTabs, CanExecuteCommand);
+            FindNextCommand = new RelayCommand(FindNext, CanExecuteCommand);
+            FindPreviousCommand = new RelayCommand(FindPrevious, CanExecuteCommand);
+            CloseSearchPanelCommand = new RelayCommand(CloseSearchPanel, CanExecuteCommand);
+            SelectTabThemeCommand = new RelayCommand<string>(SelectTabTheme, CanExecuteCommand);
+            EditTitleCommand = new AsyncCommand(EditTitle, CanExecuteCommand);
+            DuplicateTabCommand = new RelayCommand(DuplicateTab, CanExecuteCommand);
 
             if (!String.IsNullOrEmpty(terminalState))
             {
@@ -146,8 +146,12 @@ namespace FluentTerminal.App.ViewModels
 
         }
 
+        private bool _disposalRequested;
+
         public void DisposalPrepare()
         {
+            _disposalRequested = true;
+            CloseCommand = null;
             TerminalView.DisposalPrepare();
             TerminalView = null;
             Terminal = null;
@@ -186,7 +190,7 @@ namespace FluentTerminal.App.ViewModels
 
         public string XtermBufferState { get; private set; }
 
-        public RelayCommand CloseCommand { get; }
+        public RelayCommand CloseCommand { get; private set; }
 
         public RelayCommand CloseRightTabsCommand { get; }
 
@@ -303,6 +307,8 @@ namespace FluentTerminal.App.ViewModels
             set => Set(ref _terminalTheme, value);
         }
 
+        public bool Initialized { get; set; }
+
         public string TabTitle
         {
             get => _tabTitle;
@@ -392,6 +398,21 @@ namespace FluentTerminal.App.ViewModels
             SearchText = string.Empty;
             ShowSearchPanel = false;
             FocusTerminal();
+        }
+
+        private bool CanExecuteCommand<T>(T a)
+        {
+            return CanExecuteCommand();
+        }
+
+        private bool CanExecuteCommand()
+        {
+            return (Initialized == true && _disposalRequested == false);
+        }
+
+        private async void CloseTab()
+        {
+             await TryClose().ConfigureAwait(false);
         }
 
         private void CloseLeftTabs()

--- a/FluentTerminal.App/Utilities/DebouncedAction.cs
+++ b/FluentTerminal.App/Utilities/DebouncedAction.cs
@@ -9,49 +9,56 @@ namespace FluentTerminal.App.Utilities
         private DispatcherTimer timer;
         private readonly CoreDispatcher _dispatcher;
         private readonly TimeSpan _interval;
-        private readonly WeakReference<Action<T>> _action;
+        private Action<T> _action;
         private T _parameter;
 
         public DebouncedAction(CoreDispatcher dispatcher, TimeSpan interval, Action<T> action)
         {
             _dispatcher = dispatcher;
             _interval = interval;
-            _action = new WeakReference<Action<T>>(action);
+            _action = action;
         }
 
         public void Invoke(T parameter)
         {
             _parameter = parameter;
 
-            timer?.Stop();
-            timer = null;
+            ResetTimer();
 
             timer = new DispatcherTimer
             {
                 Interval = _interval
             };
-            timer.Tick += Timer_Tick;
+            timer.Tick += async (s, e) =>
+            {
+                if (!ResetTimer())
+                {
+                    return;
+                }
+
+                await _dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                {
+                    _action.Invoke(_parameter);
+                });
+            };
             timer.Start();
         }
 
-        private async void Timer_Tick(object sender, object e)
+        public void Stop()
+        {
+            ResetTimer();
+            _action = null;
+        }
+
+        private bool ResetTimer()
         {
             if (timer == null)
             {
-                return;
+                return false;
             }
-
-            timer?.Stop();
-            timer.Tick -= Timer_Tick;
+            timer.Stop();
             timer = null;
-
-            await _dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-            {
-                if (_action.TryGetTarget(out Action<T> target))
-                {
-                    target.Invoke(_parameter);
-                }
-            });
+            return true;
         }
     }
 }

--- a/FluentTerminal.App/Views/TerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/TerminalView.xaml.cs
@@ -25,6 +25,7 @@ namespace FluentTerminal.App.Views
             TerminalContainer.Children.Add((UIElement)_terminalView);
             _terminalView.Initialize(ViewModel);
             ViewModel.TerminalView = _terminalView;
+            ViewModel.Initialized = true;
         }
 
         public void DisposalPrepare()

--- a/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
@@ -198,6 +198,9 @@ namespace FluentTerminal.App.Views
 
         public void DisposalPrepare()
         {
+            _optionsChanged.Stop();
+            _sizeChanged.Stop();
+            _unblockOutput.Stop();
             ViewModel = null;
         }
 
@@ -410,12 +413,13 @@ namespace FluentTerminal.App.Views
 
         private async void Terminal_Closed(object sender, EventArgs e)
         {
+            ViewModel.Terminal.OutputReceived -= Terminal_OutputReceived;
+            ViewModel.Terminal.Closed -= Terminal_Closed;
             await ViewModel.ApplicationView.RunOnDispatcherThread(() =>
             {
                 _webView.NavigationCompleted -= _webView_NavigationCompleted;
                 _webView.NavigationStarting -= _webView_NavigationStarting;
-                ViewModel.Terminal.OutputReceived -= Terminal_OutputReceived;
-                ViewModel.Terminal.Closed -= Terminal_Closed;
+
                 _webView?.Navigate(new Uri("about:blank"));
                 Root.Children.Remove(_webView);
                 _webView = null;


### PR DESCRIPTION
- Reset Action reference from DebouncedAction instance.
- Prevent crash on close of uninitilized terminal.

Related to https://github.com/jumptrading/FluentTerminal/issues/204, https://github.com/jumptrading/FluentTerminal/issues/194

https://github.com/jumptrading/FluentTerminal/issues/204 was introduced by recent changes to avoid memory leaks.