### PR TITLE
Avoid crash on user input processing before ConPTY is fully initialized.

### DIFF
--- a/FluentTerminal.SystemTray/Services/ConPty/ConPtySession.cs
+++ b/FluentTerminal.SystemTray/Services/ConPty/ConPtySession.cs
@@ -27,7 +27,7 @@ namespace FluentTerminal.SystemTray.Services.ConPty
 
         public void Resize(TerminalSize size)
         {
-            _terminal.Resize(size.Columns, size.Rows);
+            _terminal?.Resize(size.Columns, size.Rows);
             _terminalSize = size;
         }
 
@@ -106,7 +106,7 @@ namespace FluentTerminal.SystemTray.Services.ConPty
 
         public void Write(byte[] data)
         {
-            _terminal.WriteToPseudoConsole(data);
+            _terminal?.WriteToPseudoConsole(data);
         }
 
         public void Pause(bool value)

--- a/FluentTerminal.SystemTray/Services/ConPty/Terminal.cs
+++ b/FluentTerminal.SystemTray/Services/ConPty/Terminal.cs
@@ -118,8 +118,8 @@ namespace FluentTerminal.SystemTray.Services.ConPty
         /// </summary>
         public void WriteToPseudoConsole(byte[] data)
         {
-            _consoleInputWriter.Write(data, 0, data.Length);
-            _consoleInputWriter.Flush();
+            _consoleInputWriter?.Write(data, 0, data.Length);
+            _consoleInputWriter?.Flush();
         }
 
         /// <summary>


### PR DESCRIPTION
Related to https://github.com/jumptrading/FluentTerminal/issues/194

Sending user input to not yet fully initialized terminal leads to crash on unhandled null pointer reference exception.