### PR TITLE
Terminal settings option to customize XTermJS word separator chars list.

### DIFF
--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -435,7 +435,8 @@ namespace FluentTerminal.App.Services.Implementation
                 BoldText = false,
                 BackgroundOpacity = 0.8,
                 Padding = 12,
-                ScrollBackLimit = 1000
+                ScrollBackLimit = 1000,
+                WordSeparator = " ()[]{}:;|│!&*<>@&quot;&squo;"
             };
         }
 

--- a/FluentTerminal.App.ViewModels/Settings/TerminalPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/TerminalPageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using FluentTerminal.App.Services;
 using FluentTerminal.App.Services.Utilities;
+using FluentTerminal.App.ViewModels.Utilities;
 using FluentTerminal.Models;
 using FluentTerminal.Models.Enums;
 using GalaSoft.MvvmLight;
@@ -134,6 +135,21 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
+        public string WordSeparator
+        {
+            get => WebViewSpecialCharEncoder.Decode(_terminalOptions.WordSeparator);
+            set
+            {
+                value = WebViewSpecialCharEncoder.Encode(value);
+                if (_terminalOptions.WordSeparator != value)
+                {
+                    _terminalOptions.WordSeparator = value;
+                    _settingsService.SaveTerminalOptions(_terminalOptions);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
         public bool BoldText
         {
             get => _terminalOptions.BoldText;
@@ -226,6 +242,7 @@ namespace FluentTerminal.App.ViewModels.Settings
                 BackgroundOpacity = defaults.BackgroundOpacity;
                 ScrollBackLimit = defaults.ScrollBackLimit.ToString();
                 ShowTextCopied = defaults.ShowTextCopied;
+                WordSeparator = defaults.WordSeparator;
             }
         }
 

--- a/FluentTerminal.App.ViewModels/Utilities/WebViewSpecialCharEncoder.cs
+++ b/FluentTerminal.App.ViewModels/Utilities/WebViewSpecialCharEncoder.cs
@@ -1,0 +1,15 @@
+﻿namespace FluentTerminal.App.ViewModels.Utilities
+{
+    public static class WebViewSpecialCharEncoder
+    {
+        public static string Encode(string value)
+        {
+            return value.Replace("\"", "&quot;").Replace("'", "&squo;").Replace("\\", "&bsol;");
+        }
+
+        public static string Decode(string value)
+        {
+            return value.Replace("&quot;", "\"").Replace("&squo;", "'").Replace("&bsol;", "\\");
+        }
+    }
+}

--- a/FluentTerminal.App/Strings/en/Resources.resw
+++ b/FluentTerminal.App/Strings/en/Resources.resw
@@ -1007,4 +1007,8 @@ Fuzzy</comment>
   <data name="EnvironmentVariables.Text" xml:space="preserve">
     <value>Environment variables</value>
   </data>
+  <data name="WordSeparator.Header" xml:space="preserve">
+    <value>Select-by-word characters</value>
+    <comment>TerminalSettings.xaml</comment>
+  </data>
 </root>

--- a/FluentTerminal.App/Views/SettingsPages/TerminalSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/TerminalSettings.xaml
@@ -154,6 +154,13 @@
                     Header="Text copied notification"
                     IsOn="{x:Bind ViewModel.ShowTextCopied, Mode=TwoWay}" />
 
+                <TextBox
+                    Width="200"
+                    Margin="{StaticResource ItemMargin}"
+                    HorizontalAlignment="Left"
+                    x:Uid="WordSeparator"
+                    Header="Select-by-word characters"
+                    Text="{x:Bind ViewModel.WordSeparator, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
@@ -353,17 +353,17 @@ namespace FluentTerminal.App.Views
             return JsonConvert.DeserializeObject<TerminalSize>(size);
         }
 
-        private Task<string> ExecuteScriptAsync(string script)
+        private async Task<string> ExecuteScriptAsync(string script)
         {
             try
             {
-                return _webView.InvokeScriptAsync("eval", new[] { script }).AsTask();
+                return await _webView.InvokeScriptAsync("eval", new[] { script }).AsTask();
             }
             catch (Exception e)
             {
-                Debug.WriteLine($"Exception while running:\n \"{script}\"\n\n {e}");
+                Logger.Instance.Error($"Exception while running:\n \"{script}\"\n\n {e}");
             }
-            return Task.FromResult(string.Empty);
+            return await Task.FromResult(string.Empty);
         }
 
         private IEnumerable<KeyBinding> FlattenKeyBindings(IDictionary<string, ICollection<KeyBinding>> commandKeyBindings, IEnumerable<ShellProfile> profiles, IEnumerable<SshProfile> sshprofiles)

--- a/FluentTerminal.Client/src/index.ts
+++ b/FluentTerminal.Client/src/index.ts
@@ -28,6 +28,16 @@ let serializeAddon: any;
 let socket: WebSocket;
 const terminalContainer = document.getElementById('terminal-container');
 
+function replaceAll(searchString, replaceString, str) {
+  return str.split(searchString).join(replaceString);
+}
+
+function DecodeSpecialChars(data: string) {
+  data = replaceAll("&quot;", "\"", data);
+  data = replaceAll("&squo;", "'", data);
+  return replaceAll("&bsol;", "\\", data);
+}
+
 window.serializeTerminal = () => {
   let serialized = serializeAddon.serialize();
   return serialized;
@@ -58,7 +68,7 @@ window.createTerminal = (options, theme, keyBindings) => {
     allowTransparency: true,
     theme: theme,
     windowsMode: true,
-    wordSeparator: ' ()[]{}\'":;|│!&*<>@'
+    wordSeparator: DecodeSpecialChars(options.wordSeparator)
   };
 
   term = new Terminal(terminalOptions);
@@ -178,6 +188,7 @@ window.changeOptions = (options) => {
   term.setOption('fontWeight', options.boldText ? 'bold' : 'normal');
   term.setOption('fontWeightBold', options.boldText ? 'bolder' : 'bold');
   term.setOption('scrollback', options.scrollBackLimit);
+  term.setOption('wordSeparator', DecodeSpecialChars(options.wordSeparator));
   setScrollBarStyle(options.scrollBarStyle);
   setPadding(options.padding);
 }

--- a/FluentTerminal.Models/TerminalOptions.cs
+++ b/FluentTerminal.Models/TerminalOptions.cs
@@ -25,5 +25,7 @@ namespace FluentTerminal.Models
         public uint ScrollBackLimit { get; set; }
 
         public bool ShowTextCopied { get; set; }
+
+        public string WordSeparator { get; set; }
     }
 }


### PR DESCRIPTION
Introduces "Select-by-word characters" Terminal Settings option.

Related to https://github.com/jumptrading/FluentTerminal/issues/106

It's turned out that WebView doesn't work well with passing following symbols ",',\ as part of the script to be executed by JS engine. As workaround the encoding/decoding of special symbols happens both on C# and JS sides for Terminal Options values.