### PR TITLE
Avoid memory leaks after terminal window is closed.

### DIFF
--- a/FluentTerminal.App.Services/IKeyboardCommandService.cs
+++ b/FluentTerminal.App.Services/IKeyboardCommandService.cs
@@ -8,5 +8,6 @@ namespace FluentTerminal.App.Services
 
         void SendCommand(string command);
         void DeregisterCommandHandler(string command);
+        void ClearCommandHandlers();
     }
 }

--- a/FluentTerminal.App.Services/Implementation/KeyboardCommandService.cs
+++ b/FluentTerminal.App.Services/Implementation/KeyboardCommandService.cs
@@ -42,5 +42,10 @@ namespace FluentTerminal.App.Services.Implementation
 
             throw new KeyNotFoundException($"No handler registered for command: {command}");
         }
+
+        public void ClearCommandHandlers()
+        {
+            _commandHandlers.Clear();
+        }
     }
 }

--- a/FluentTerminal.App.Services/Terminal.cs
+++ b/FluentTerminal.App.Services/Terminal.cs
@@ -93,7 +93,7 @@ namespace FluentTerminal.App.Services
         /// <returns></returns>
         public Task<string> GetSelectedText()
         {
-            return _selectedTextCallback();
+            return _selectedTextCallback?.Invoke();
         }
 
         /// <summary>

--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -107,6 +107,28 @@ namespace FluentTerminal.App.ViewModels
 
         private void OnClosed(object sender, EventArgs e)
         {
+            _settingsService.CurrentThemeChanged -= OnCurrentThemeChanged;
+            _settingsService.ApplicationSettingsChanged -= OnApplicationSettingsChanged;
+            _settingsService.TerminalOptionsChanged -= OnTerminalOptionsChanged;
+            _settingsService.ShellProfileAdded -= OnShellProfileAdded;
+            _settingsService.ShellProfileDeleted -= OnShellProfileDeleted;
+            _settingsService.SshProfileAdded -= OnSshProfileAdded;
+            _settingsService.SshProfileDeleted -= OnSshProfileDeleted;
+
+            ApplicationView.CloseRequested -= OnCloseRequest;
+            ApplicationView.Closed -= OnClosed;
+            Terminals.CollectionChanged -= OnTerminalsCollectionChanged;
+
+            _keyboardCommandService.ClearCommandHandlers();
+
+            _applicationSettings = null;
+
+            AddLocalShellCommand = null;
+            AddSshShellCommand = null;
+            AddQuickShellCommand = null;
+            ShowAboutCommand = null;
+            ShowSettingsCommand = null;
+
             Closed?.Invoke(this, e);
         }
 
@@ -157,9 +179,9 @@ namespace FluentTerminal.App.ViewModels
             ActivatedMv?.Invoke(this, EventArgs.Empty);
         }
 
-        public RelayCommand AddLocalShellCommand { get; }
-        public RelayCommand AddSshShellCommand { get; }
-        public RelayCommand AddQuickShellCommand { get; }
+        public RelayCommand AddLocalShellCommand { get; private set; }
+        public RelayCommand AddSshShellCommand { get; private set; }
+        public RelayCommand AddQuickShellCommand { get; private set; }
 
         public string WindowTitle
         {
@@ -223,9 +245,9 @@ namespace FluentTerminal.App.ViewModels
             }
         }
 
-        public RelayCommand ShowAboutCommand { get; }
+        public RelayCommand ShowAboutCommand { get; private set; }
 
-        public RelayCommand ShowSettingsCommand { get; }
+        public RelayCommand ShowSettingsCommand { get; private set; }
 
         public TabsPosition TabsPosition
         {

--- a/FluentTerminal.App/Adapters/ApplicationViewAdapter.cs
+++ b/FluentTerminal.App/Adapters/ApplicationViewAdapter.cs
@@ -31,6 +31,7 @@ namespace FluentTerminal.App.Adapters
 
         private void _applicationView_Consolidated(ApplicationView sender, ApplicationViewConsolidatedEventArgs args)
         {
+            _applicationView.Consolidated -= _applicationView_Consolidated;
             Closed?.Invoke(this, EventArgs.Empty);
         }
 

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -608,6 +608,8 @@ namespace FluentTerminal.App
                 }
 
                 _mainViewModels.Remove(viewModel);
+
+                Window.Current.Content = null;
             }
         }
 

--- a/FluentTerminal.App/Converters/TerminalViewModelToViewConverter.cs
+++ b/FluentTerminal.App/Converters/TerminalViewModelToViewConverter.cs
@@ -23,6 +23,7 @@ namespace FluentTerminal.App.Converters
                 terminalView.DisposalPrepare();
             }
             _viewDictionary.Remove(viewModel);
+            GC.Collect();
         }
 
         public object Convert(object value, Type targetType, object parameter, string language)

--- a/FluentTerminal.App/Views/MainPage.xaml.cs
+++ b/FluentTerminal.App/Views/MainPage.xaml.cs
@@ -19,7 +19,7 @@ namespace FluentTerminal.App.Views
 {
     public sealed partial class MainPage : Page, INotifyPropertyChanged
     {
-        private readonly CoreApplicationViewTitleBar coreTitleBar = CoreApplication.GetCurrentView().TitleBar;
+        private CoreApplicationViewTitleBar coreTitleBar = CoreApplication.GetCurrentView().TitleBar;
 
         public event PropertyChangedEventHandler PropertyChanged;
 
@@ -44,21 +44,24 @@ namespace FluentTerminal.App.Views
 
         public MainViewModel ViewModel { get; private set; }
 
+        private long _propertyChangedCallbackToken;
+
         public MainPage()
         {
             InitializeComponent();
             Root.DataContext = this;
             Window.Current.SetTitleBar(TitleBar);
             Loaded += OnLoaded;
-            Unloaded += OnUnloaded;
             DraggingHappensChanged += MainPage_DraggingHappensChanged;
             Window.Current.Activated += OnWindowActivated;
-            RegisterPropertyChangedCallback(RequestedThemeProperty, (s, e) =>
-            {
-                ContrastHelper.SetTitleBarButtonsForTheme(RequestedTheme);
-            });
+            _propertyChangedCallbackToken = RegisterPropertyChangedCallback(RequestedThemeProperty, OnRequestedThemeProperty);
 
             ApplicationView.PreferredLaunchWindowingMode = ApplicationViewWindowingMode.Auto;
+        }
+
+        private void OnRequestedThemeProperty(DependencyObject sender, DependencyProperty dp)
+        {
+            ContrastHelper.SetTitleBarButtonsForTheme(RequestedTheme);
         }
 
         private async void MainPage_DraggingHappensChanged(object sender, bool e)
@@ -78,21 +81,51 @@ namespace FluentTerminal.App.Views
             if (e.Parameter is MainViewModel viewModel)
             {
                 ViewModel = viewModel;
+                ViewModel.Closed += ViewModel_Closed;
             }
+            base.OnNavigatedTo(e);
+        }
+
+        private void ViewModel_Closed(object sender, EventArgs e)
+        {
+            TopTabBar.TabDraggedOutside -= TabBar_TabDraggedOutside;
+            TopTabBar.TabWindowChanged -= TabView_Drop;
+            TopTabBar.TabDraggingCompleted -= TabBar_TabDraggingCompleted;
+            TopTabBar.TabDraggingChanged -= TabBar_TabDraggingChanged;
+
+            BottomTabBar.TabDraggedOutside -= TabBar_TabDraggedOutside;
+            BottomTabBar.TabWindowChanged -= TabView_Drop;
+            BottomTabBar.TabDraggingCompleted -= TabBar_TabDraggingCompleted;
+            BottomTabBar.TabDraggingChanged -= TabBar_TabDraggingChanged;
+
+            TopTabBar.DisposalPrepare();
+            BottomTabBar.DisposalPrepare();
+
+            UnregisterPropertyChangedCallback(RequestedThemeProperty, _propertyChangedCallbackToken);
+
+            Loaded -= OnLoaded;
+            DraggingHappensChanged -= MainPage_DraggingHappensChanged;
+            Window.Current.Activated -= OnWindowActivated;
+
+            coreTitleBar.LayoutMetricsChanged -= OnLayoutMetricsChanged;
+
+            ViewModel.Closed -= ViewModel_Closed;
+            ViewModel = null;
+            Root.DataContext = null;
+            Window.Current.SetTitleBar(null);
+
+            coreTitleBar = null;
+            Bindings.StopTracking();
+            TerminalContainer.Content = null;
         }
 
         private void OnWindowActivated(object sender, WindowActivatedEventArgs e)
         {
             if (e.WindowActivationState != CoreWindowActivationState.Deactivated && TerminalContainer.Content is TerminalView terminal)
             {
-                terminal.ViewModel.FocusTerminal();
+                terminal.ViewModel?.FocusTerminal();
                 ViewModel.FocusWindow();
             }
-        }
-
-        private void OnUnloaded(object sender, RoutedEventArgs e)
-        {
-            coreTitleBar.LayoutMetricsChanged -= OnLayoutMetricsChanged;
         }
 
         private void OnLoaded(object sender, RoutedEventArgs e)

--- a/FluentTerminal.App/Views/TabBar.xaml.cs
+++ b/FluentTerminal.App/Views/TabBar.xaml.cs
@@ -25,13 +25,32 @@ namespace FluentTerminal.App.Views
         public static readonly DependencyProperty SelectedItemProperty =
             DependencyProperty.Register(nameof(SelectedItem), typeof(object), typeof(TabBar), new PropertyMetadata(null));
 
+        private long _scrollableWidthChangedToken;
+
         public TabBar()
         {
             InitializeComponent();
-            ScrollViewer.RegisterPropertyChangedCallback(ScrollViewer.ScrollableWidthProperty, OnScrollableWidthChanged);
+            _scrollableWidthChangedToken = ScrollViewer.RegisterPropertyChangedCallback(ScrollViewer.ScrollableWidthProperty, OnScrollableWidthChanged);
             ListView.SelectionChanged += OnListViewSelectionChanged;
             ScrollLeftButton.Tapped += OnScrollLeftButtonTapped;
             ScrollRightButton.Tapped += OnScrollRightButtonTapped;
+        }
+
+        public void DisposalPrepare()
+        {
+            ListView.ItemsSource = null;
+            ListView.SelectedItem = null;
+
+            ItemsSource = null;
+            AddCommand = null;
+            SelectedItem = null;
+
+            Bindings.StopTracking();
+
+            ScrollViewer.UnregisterPropertyChangedCallback(ScrollViewer.ScrollableWidthProperty, _scrollableWidthChangedToken);
+            ListView.SelectionChanged -= OnListViewSelectionChanged;
+            ScrollLeftButton.Tapped -= OnScrollLeftButtonTapped;
+            ScrollRightButton.Tapped -= OnScrollRightButtonTapped;
         }
 
         public RelayCommand AddCommand

--- a/FluentTerminal.App/Views/TerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/TerminalView.xaml.cs
@@ -8,7 +8,7 @@ namespace FluentTerminal.App.Views
 {
     public sealed partial class TerminalView : UserControl
     {
-        private readonly ITerminalView _terminalView;
+        private ITerminalView _terminalView;
 
         public TerminalView(TerminalViewModel viewModel)
         {
@@ -32,6 +32,7 @@ namespace FluentTerminal.App.Views
         {
             Bindings.StopTracking();
             TerminalContainer.Children.Remove((UIElement)_terminalView);
+            _terminalView = null;
 
             ViewModel.SearchStarted -= OnSearchStarted;
             ViewModel.Activated -= OnActivated;

--- a/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
@@ -418,8 +418,10 @@ namespace FluentTerminal.App.Views
 
         private async void Terminal_Closed(object sender, EventArgs e)
         {
-            ViewModel.Terminal.OutputReceived -= Terminal_OutputReceived;
             ViewModel.Terminal.Closed -= Terminal_Closed;
+            ViewModel.Terminal.OutputReceived -= Terminal_OutputReceived;
+            ViewModel.Terminal.RegisterSelectedTextCallback(null);
+            _mediatorTaskCTSource.Cancel();
             await ViewModel.ApplicationView.RunOnDispatcherThread(() =>
             {
                 _webView.NavigationCompleted -= _webView_NavigationCompleted;
@@ -438,7 +440,7 @@ namespace FluentTerminal.App.Views
 
                 _copyMenuItem.Click -= Copy_Click;
                 _pasteMenuItem.Click -= Paste_Click;
-                _mediatorTaskCTSource.Cancel();
+                
 
                 if (Window.Current.Content is Frame frame && frame.Content is Page mainPage)
                 {

--- a/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
@@ -49,6 +49,7 @@ namespace FluentTerminal.App.Views
         private ManualResetEventSlim _outputBlocked;
         private MemoryStream _outputBlockedBuffer;
         private readonly DebouncedAction<bool> _unblockOutput;
+        private TerminalBridge _terminalBridge;
 
         public XtermTerminalView()
         {
@@ -197,6 +198,11 @@ namespace FluentTerminal.App.Views
 
         public void DisposalPrepare()
         {
+            if (_terminalBridge != null)
+            {
+                _terminalBridge.DisposalPrepare();
+                _terminalBridge = null;
+            }
             _optionsChanged.Stop();
             _sizeChanged.Stop();
             _unblockOutput.Stop();
@@ -282,8 +288,8 @@ namespace FluentTerminal.App.Views
 
         private void _webView_NavigationStarting(WebView sender, WebViewNavigationStartingEventArgs args)
         {
-            var bridge = new TerminalBridge(this);
-            _webView.AddWebAllowedObject("terminalBridge", bridge);
+            _terminalBridge = new TerminalBridge(this);
+            _webView.AddWebAllowedObject("terminalBridge", _terminalBridge);
         }
 
         private void Copy_Click(object sender, RoutedEventArgs e)

--- a/FluentTerminal.RuntimeComponent/WebAllowedObjects/TerminalBridge.cs
+++ b/FluentTerminal.RuntimeComponent/WebAllowedObjects/TerminalBridge.cs
@@ -7,46 +7,51 @@ namespace FluentTerminal.RuntimeComponent.WebAllowedObjects
     [AllowForWeb]
     public sealed class TerminalBridge
     {
-        private readonly IxtermEventListener _terminalEventListener;
+        private IxtermEventListener _terminalEventListener;
 
         public TerminalBridge(IxtermEventListener terminalEventListener)
         {
             _terminalEventListener = terminalEventListener;
         }
 
+        public void DisposalPrepare()
+        {
+            _terminalEventListener = null;
+        }
+
         public void NotifySizeChanged(int columns, int rows)
         {
-            _terminalEventListener.OnTerminalResized(columns, rows);
+            _terminalEventListener?.OnTerminalResized(columns, rows);
         }
 
         public void NotifyTitleChanged(string title)
         {
-            _terminalEventListener.OnTitleChanged(title);
+            _terminalEventListener?.OnTitleChanged(title);
         }
 
         public void InvokeCommand(string command)
         {
-            _terminalEventListener.OnKeyboardCommand(command);
+            _terminalEventListener?.OnKeyboardCommand(command);
         }
 
         public void NotifyRightClick(int x, int y, bool hasSelection)
         {
-            _terminalEventListener.OnMouseClick(MouseButton.Right, x, y, hasSelection);
+            _terminalEventListener?.OnMouseClick(MouseButton.Right, x, y, hasSelection);
         }
 
         public void NotifyMiddleClick(int x, int y, bool hasSelection)
         {
-            _terminalEventListener.OnMouseClick(MouseButton.Middle, x, y, hasSelection);
+            _terminalEventListener?.OnMouseClick(MouseButton.Middle, x, y, hasSelection);
         }
 
         public void NotifySelectionChanged(string selection)
         {
-            _terminalEventListener.OnSelectionChanged(selection);
+            _terminalEventListener?.OnSelectionChanged(selection);
         }
 
         public void ReportError(string error)
         {
-            _terminalEventListener.OnError(error);
+            _terminalEventListener?.OnError(error);
         }
     }
 }


### PR DESCRIPTION
- Force GC.Collect() on closing of terminal;
- Prepare MainPage, MainViewModel, TabBar, TerminalBridge for disposal.

related to https://github.com/jumptrading/FluentTerminal/issues/190

With PR's changes applied the memory consumption after 50 new windows opened and closed should be decreased from ~1100 MB to ~260 MB.