### PR TITLE
Fixed a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A Terminal Emulator based on UWP and web technologies.
 ![Terminal window](Screenshots/terminal.jpg)
 ![Settings window](Screenshots/settings.jpg)
 
-## Laguages
+## Languages
 - English
 - German
 - Spanish


### PR DESCRIPTION
Changes `Laguages` to `Languages` in README.md  
That's not a real issue but I think keeping the README clean is a nice thing to do for newcomers