### PR TITLE
Enable app downgrading in the install script

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -449,11 +449,11 @@ function InstallPackageWithDependencies
         {
             Write-Host ([UiStrings]::DependenciesFound)
             $DependencyPackages.FullName
-            Add-AppxPackage -Path $DeveloperPackagePath.FullName -DependencyPath $DependencyPackages.FullName -ForceApplicationShutdown
+            Add-AppxPackage -Path $DeveloperPackagePath.FullName -DependencyPath $DependencyPackages.FullName -ForceApplicationShutdown -ForceUpdateFromAnyVersion
         }
         else
         {
-            Add-AppxPackage -Path $DeveloperPackagePath.FullName -ForceApplicationShutdown
+            Add-AppxPackage -Path $DeveloperPackagePath.FullName -ForceApplicationShutdown -ForceUpdateFromAnyVersion
         }
         $AddPackageSucceeded = $?
     }


### PR DESCRIPTION
Sometimes when an update has an issue it can be useful to downgrade, this is what this change allows for (especially when using Chocolatey for package management).

The [official Powershell documentation](https://docs.microsoft.com/en-us/powershell/module/appx/add-appxpackage?view=win10-ps) was not very verbose about this flag - https://github.com/MicrosoftDocs/windows-powershell-docs/issues/1398

So I'm assuming the flag has a similar behaviour as the one described here: https://docs.microsoft.com/en-us/uwp/schemas/appinstallerschema/element-force-update-from-any-version