### PR TITLE
Revert back passing of full ssh.exe path to allow WinPTY locate execu…

### DIFF
--- a/FluentTerminal.SystemTray/Utilities.cs
+++ b/FluentTerminal.SystemTray/Utilities.cs
@@ -478,8 +478,33 @@ namespace FluentTerminal.SystemTray
             {
                 return GetMoshPath();
             }
+            else if (location.Equals(Constants.SshCommandName, StringComparison.OrdinalIgnoreCase) ||
+                     location.Equals($"{Constants.SshCommandName}.exe", StringComparison.OrdinalIgnoreCase))
+            {
+                return GetSshPath();
+            }
 
             return location;
+        }
+
+        private static string GetSshPath()
+        {
+            //
+            // See https://stackoverflow.com/a/25919981
+            //
+
+            string path;
+            if (Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess)
+            {
+                path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), @"Sysnative");
+            }
+            else
+            {
+                path = Environment.GetFolderPath(Environment.SpecialFolder.System);
+            }
+
+            path = Path.Combine(path, @"OpenSSH\ssh.exe");
+            return System.IO.File.Exists(path) ? path : null;
         }
 
         private static string GetMoshPath()


### PR DESCRIPTION
…table without error.

Fixes https://github.com/jumptrading/FluentTerminal/issues/219

Was introduced with https://github.com/felixse/FluentTerminal/commit/e88fb78e9d1e481f968a1ceaa42889cb1c232976#diff-cd75e42d7c72afd7283483cd9a6cd982L504