### PR TITLE
Default to WinPty settings option.

### DIFF
--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -40,7 +40,8 @@ namespace FluentTerminal.App.Services.Implementation
                 MuteTerminalBeeps = true,
                 EnableLogging = false,
                 PrintableOutputOnly = true,
-                LogDirectoryPath = logDirectoryPath
+                LogDirectoryPath = logDirectoryPath,
+                UseConPty = true
             };
         }
 

--- a/FluentTerminal.App.ViewModels/Profiles/SshConnectViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Profiles/SshConnectViewModel.cs
@@ -123,7 +123,9 @@ namespace FluentTerminal.App.ViewModels.Profiles
         public SshConnectViewModel(ISettingsService settingsService, IApplicationView applicationView,
             ITrayProcessCommunicationService trayProcessCommunicationService, IFileSystemService fileSystemService,
             SshProfile original = null) : base(settingsService, applicationView, true,
-            original ?? new SshProfile { UseMosh = settingsService.GetApplicationSettings().UseMoshByDefault })
+            original ?? new SshProfile { UseMosh = settingsService.GetApplicationSettings().UseMoshByDefault,
+                RequestConPty = settingsService.GetApplicationSettings().UseConPty
+            })
         {
             _trayProcessCommunicationService = trayProcessCommunicationService;
             _fileSystemService = fileSystemService;

--- a/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
@@ -218,6 +218,20 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
+        public bool UseConPty
+        {
+            get => _applicationSettings.UseConPty;
+            set
+            {
+                if (_applicationSettings.UseConPty != value)
+                {
+                    _applicationSettings.UseConPty = value;
+                    _settingsService.SaveApplicationSettings(_applicationSettings);
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
         public bool BottomIsSelected
         {
             get => TabsPosition == TabsPosition.Bottom;
@@ -390,6 +404,7 @@ namespace FluentTerminal.App.ViewModels.Settings
                 EnableLogging = defaults.EnableLogging;
                 PrintableOutputOnly = defaults.PrintableOutputOnly;
                 LogDirectoryPath = defaults.LogDirectoryPath;
+                UseConPty = defaults.UseConPty;
             }
         }
 

--- a/FluentTerminal.App.ViewModels/Settings/ProfilesPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/ProfilesPageViewModel.cs
@@ -90,7 +90,8 @@ namespace FluentTerminal.App.ViewModels.Settings
                 Id = Guid.NewGuid(),
                 PreInstalled = false,
                 Name = "New profile",
-                KeyBindings = new List<KeyBinding>()
+                KeyBindings = new List<KeyBinding>(),
+                UseConPty = _settingsService.GetApplicationSettings().UseConPty
             };
 
             AddShellProfile(shellProfile);

--- a/FluentTerminal.App.ViewModels/Settings/SshProfilesPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/SshProfilesPageViewModel.cs
@@ -75,7 +75,8 @@ namespace FluentTerminal.App.ViewModels.Settings
                 PreInstalled = false,
                 Name = "New SSH profile",
                 KeyBindings = new List<KeyBinding>(),
-                UseMosh = _settingsService.GetApplicationSettings().UseMoshByDefault
+                UseMosh = _settingsService.GetApplicationSettings().UseMoshByDefault,
+                RequestConPty = _settingsService.GetApplicationSettings().UseConPty
             };
 
             AddSshProfile(shellProfile);

--- a/FluentTerminal.App/ViewModels/CommandProfileProviderViewModel.cs
+++ b/FluentTerminal.App/ViewModels/CommandProfileProviderViewModel.cs
@@ -70,7 +70,8 @@ namespace FluentTerminal.App.ViewModels
             IApplicationDataContainer historyContainer, ShellProfile original = null) : base(settingsService,
             applicationView, false,
             original ?? new ShellProfile
-                {UseConPty = ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7)})
+                {UseConPty = settingsService.GetApplicationSettings().UseConPty &&
+                    ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7)})
         {
             _trayProcessCommunicationService = trayProcessCommunicationService;
             _historyContainer = historyContainer;

--- a/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/GeneralSettings.xaml
@@ -202,6 +202,12 @@
                             IsEnabled="{x:Bind ViewModel.EnableLogging, Mode=OneWay}"/>
                     </StackPanel>
                 </StackPanel>
+
+                <ToggleSwitch
+                    x:Uid="UseConPty"
+                    Margin="{StaticResource ItemMargin}"
+                    Header="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=UseConPty}"
+                    IsOn="{x:Bind ViewModel.UseConPty, Mode=TwoWay}" />
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/FluentTerminal.Models/ApplicationSettings.cs
+++ b/FluentTerminal.Models/ApplicationSettings.cs
@@ -23,5 +23,6 @@ namespace FluentTerminal.Models
         public bool EnableLogging { get; set; }
         public bool PrintableOutputOnly { get; set; }
         public string LogDirectoryPath { get; set; }
+        public bool UseConPty { get; set; }
     }
 }

--- a/FluentTerminal.Models/SshProfile.cs
+++ b/FluentTerminal.Models/SshProfile.cs
@@ -40,6 +40,14 @@ namespace FluentTerminal.Models
             UseConPty = ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7); // Windows 10 1809+
         }
 
+        public bool RequestConPty
+        {
+            set
+            {
+                UseConPty = UseConPty && value;
+            }
+        }
+
         protected SshProfile(SshProfile other) : base(other)
         {
             Host = other.Host;


### PR DESCRIPTION
Moves back global option to have preferred pty mode globally (ConPty or WinPty).

Related to https://github.com/jumptrading/FluentTerminal/issues/223

It allows to save few seconds of time on each opening of remote machine from SSH dialogs. 