### PR TITLE
Handle IOException on user input write to pty.

### DIFF
--- a/FluentTerminal.SystemTray/Services/TerminalsManager.cs
+++ b/FluentTerminal.SystemTray/Services/TerminalsManager.cs
@@ -153,7 +153,14 @@ namespace FluentTerminal.SystemTray.Services
         {
             if (_terminals.TryGetValue(id, out TerminalSessionInfo sessionInfo))
             {
-                sessionInfo.Session.Write(data);
+                try
+                {
+                    sessionInfo.Session.Write(data);
+                }
+                catch (IOException e)
+                {
+                    Logger.Instance.Error($"TerminalsManager.Write: sending user input to terminal with id '{id}' failed with exception: {e}");
+                }
             }
         }
 


### PR DESCRIPTION
Related to https://github.com/jumptrading/FluentTerminal/issues/224

It seems that running CLI process might error out, but user input writing to PTY still happens and crashes tray process with unhandled IOException.
It should be fine to ignore user input in case if IO was closed/invalidated.

So far, the issues always started from receiving "lost connection to agent" error from WinPty https://github.com/microsoft/node-pty/blob/master/deps/winpty/src/libwinpty/winpty.cc#L277