### PR TITLE
Fix activation problem when opening a new window in a new desktop

### DIFF
--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -491,6 +491,7 @@ namespace FluentTerminal.App
             {
                 var viewModel = await CreateNewTerminalWindow().ConfigureAwait(true);
                 await viewModel.AddLocalTabAsync();
+                await ShowAsStandaloneAsync(viewModel, args.ViewSwitcher);
             }
 
             _isLaunching = false;


### PR DESCRIPTION
#513 was not perfect. Currently there's an activation problem when opening a new window in a new desktop.

1. Launch Fluent Terminal.
2. Switch to another desktop which has no Fluent Terminal window.
3. Open new window by clicking the task bar icon.
4. The new window is displayed in the foreground but is not active, that is, you can't type into the window until you click it.

With this PR it works as expected **in most cases**. I admit it sometimes fails to activate correctly, but I haven't found the cause so far.