### PR TITLE
Logging UnobservedTaskException

### DIFF
--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -68,6 +68,9 @@ namespace FluentTerminal.App
 
             UnhandledException += OnUnhandledException;
 
+            TaskScheduler.UnobservedTaskException += (sender, e) =>
+                Logger.Instance.Error(e.Exception, "Unobserved Task Exception");
+
             var applicationDataContainers = new ApplicationDataContainers
             {
                 LocalSettings = new ApplicationDataContainerAdapter(ApplicationData.Current.LocalSettings),

--- a/FluentTerminal.SystemTray/Program.cs
+++ b/FluentTerminal.SystemTray/Program.cs
@@ -78,6 +78,9 @@ namespace FluentTerminal.SystemTray
                     Logger.Instance.Initialize(logFile, config);
 
                     AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+
+                    TaskScheduler.UnobservedTaskException += (sender, e) =>
+                        Logger.Instance.Error(e.Exception, "Unobserved Task Exception");
                 });
 
                 var appCommunicationService = container.Resolve<AppCommunicationService>();


### PR DESCRIPTION
Ensuring that any unhandled TPL exceptions are logged. Without this, exceptions in fire-and-forget tasks (not awaited tasks) won't be logged.