### PR TITLE
Tab-selection in "Quick Launch" dialog

### DIFF
--- a/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml
+++ b/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml
@@ -33,7 +33,7 @@
             Margin="4,8,4,0"
             AutoMaximizeSuggestionArea="True"
             ItemsSource="{x:Bind ViewModel.Commands, Mode=OneWay}"
-            KeyUp="CommandTextBox_OnKeyUp"
+            KeyDown="CommandTextBox_OnKeyDown"
             PlaceholderText="Enter a command (e.g. 'ssh username@host')"
             PreviewKeyUp="CommandTextBox_OnPreviewKeyUp"
             QueryIcon="Find"

--- a/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml.cs
+++ b/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml.cs
@@ -188,10 +188,7 @@ namespace FluentTerminal.App.Dialogs
                     if (_lastChosenCommand != null)
                     {
                         ViewModel.Command = _lastChosenCommand.Value;
-                        CommandTextBox.Text = _lastChosenCommand.Value;
                         _tabSelectedCommand = _lastChosenCommand.Value;
-                        CommandTextBox.IsSuggestionListOpen = false;
-                        _lastChosenCommand = null;
                     }
 
                     e.Handled = false;


### PR DESCRIPTION
Solves https://github.com/jumptrading/FluentTerminal/issues/236

I've had to implement a hack to enforce Tab-selection.