### PR TITLE
`Enter` selection in "Quick Launch" immediately launches the command

### DIFF
--- a/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml
+++ b/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml
@@ -33,7 +33,7 @@
             Margin="4,8,4,0"
             AutoMaximizeSuggestionArea="True"
             ItemsSource="{x:Bind ViewModel.Commands, Mode=OneWay}"
-            KeyUp="CommandTextBox_OnKeyUp"
+            KeyDown="CommandTextBox_OnKeyDown"
             PlaceholderText="Enter a command (e.g. 'ssh username@host')"
             PreviewKeyUp="CommandTextBox_OnPreviewKeyUp"
             QueryIcon="Find"

--- a/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml
+++ b/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml
@@ -14,6 +14,7 @@
                                      IsDesignTimeCreatable=False}"
     DefaultButton="Primary"
     PrimaryButtonClick="OnPrimaryButtonClick"
+    SecondaryButtonClick="OnSecondaryButtonClick"
     PrimaryButtonText="Button1"
     SecondaryButtonText="Button2"
     mc:Ignorable="d">

--- a/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml.cs
+++ b/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml.cs
@@ -188,10 +188,7 @@ namespace FluentTerminal.App.Dialogs
                     if (_lastChosenCommand != null)
                     {
                         ViewModel.Command = _lastChosenCommand.Value;
-                        CommandTextBox.Text = _lastChosenCommand.Value;
                         _tabSelectedCommand = _lastChosenCommand.Value;
-                        CommandTextBox.IsSuggestionListOpen = false;
-                        _lastChosenCommand = null;
                     }
 
                     e.Handled = false;

--- a/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml.cs
+++ b/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml.cs
@@ -72,7 +72,11 @@ namespace FluentTerminal.App.Dialogs
 
             var error = await ViewModel.AcceptChangesAsync();
 
-            if (!string.IsNullOrEmpty(error))
+            if (string.IsNullOrEmpty(error))
+            {
+                _dialogResult = ContentDialogResult.Primary;
+            }
+            else
             {
                 args.Cancel = true;
 
@@ -176,7 +180,7 @@ namespace FluentTerminal.App.Dialogs
             }
         }
 
-        private void CommandTextBox_OnKeyUp(object sender, KeyRoutedEventArgs e)
+        private async void CommandTextBox_OnKeyUp(object sender, KeyRoutedEventArgs e)
         {
             switch (e.Key)
             {
@@ -198,9 +202,18 @@ namespace FluentTerminal.App.Dialogs
                     }
                     else
                     {
-                        _dialogResult = ContentDialogResult.Primary;
+                        var error = await ViewModel.AcceptChangesAsync();
 
-                        _showDialogOperation.Cancel();
+                        if (string.IsNullOrEmpty(error))
+                        {
+                            _dialogResult = ContentDialogResult.Primary;
+
+                            _showDialogOperation.Cancel();
+                        }
+                        else
+                        {
+                            await new MessageDialog(error, I18N.Translate("InvalidInput")).ShowAsync();
+                        }
                     }
 
                     return;


### PR DESCRIPTION
**Please merge https://github.com/felixse/FluentTerminal/pull/581 first! This one builds upon it.**

Solves https://github.com/jumptrading/FluentTerminal/issues/200.

Selecting a suggested text from auto-complete list in "Quick Launch" now works as follows:
- Selecting with `Enter` key immediately closes the dialog and launches the command;
- Selecting with `Tab` key selects the command and moves focus to the next control ("Advanced Options");
- Selecting with mouse click / tap selects the command, and the command text box retains focus.