### PR TITLE
XtermTerminalView initialization simplified

### DIFF
--- a/FluentTerminal.App.Services/IApplicationView.cs
+++ b/FluentTerminal.App.Services/IApplicationView.cs
@@ -1,6 +1,7 @@
 ﻿using FluentTerminal.App.Services.EventArgs;
 using System;
 using System.Threading.Tasks;
+using Windows.UI.Core;
 
 namespace FluentTerminal.App.Services
 {
@@ -14,7 +15,11 @@ namespace FluentTerminal.App.Services
         int Id { get; }
         string Title { get; set; }
 
-        Task RunOnDispatcherThread(Action action, bool enforceNewSchedule = true);
+        Task DispatchAsync(Action action, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal,
+            bool enforceNewSchedule = false);
+
+        Task<T> DispatchAsync<T>(Func<T> func, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal,
+            bool enforceNewSchedule = false);
 
         Task<bool> TryClose();
 

--- a/FluentTerminal.App.Services/IApplicationView.cs
+++ b/FluentTerminal.App.Services/IApplicationView.cs
@@ -15,10 +15,10 @@ namespace FluentTerminal.App.Services
         int Id { get; }
         string Title { get; set; }
 
-        Task DispatchAsync(Action action, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal,
+        Task ExecuteOnUiThreadAsync(Action action, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal,
             bool enforceNewSchedule = false);
 
-        Task<T> DispatchAsync<T>(Func<T> func, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal,
+        Task<T> ExecuteOnUiThreadAsync<T>(Func<T> func, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal,
             bool enforceNewSchedule = false);
 
         Task<bool> TryClose();

--- a/FluentTerminal.App.ViewModels/FluentTerminal.App.ViewModels.csproj
+++ b/FluentTerminal.App.ViewModels/FluentTerminal.App.ViewModels.csproj
@@ -13,4 +13,11 @@
     <ProjectReference Include="..\FluentTerminal.Models\FluentTerminal.Models.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="Windows.Foundation.UniversalApiContract">
+      <HintPath>$(MSBuildProgramFiles32)\Windows Kits\10\References\10.0.16299.0\Windows.Foundation.UniversalApiContract\5.0.0.0\Windows.Foundation.UniversalApiContract.winmd</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+
 </Project>

--- a/FluentTerminal.App.ViewModels/Profiles/ProfileProviderViewModelBase.cs
+++ b/FluentTerminal.App.ViewModels/Profiles/ProfileProviderViewModelBase.cs
@@ -215,7 +215,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
                 return;
             }
 
-            ApplicationView.DispatchAsync(() =>
+            ApplicationView.ExecuteOnUiThreadAsync(() =>
             {
                 TerminalThemes.Remove(theme);
 
@@ -228,7 +228,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
 
         private void OnThemeAdded(ThemeAddedMessage message)
         {
-            ApplicationView.DispatchAsync(() => TerminalThemes.Add(message.Theme), CoreDispatcherPriority.Low, true);
+            ApplicationView.ExecuteOnUiThreadAsync(() => TerminalThemes.Add(message.Theme), CoreDispatcherPriority.Low);
         }
 
         private void Initialize(ShellProfile profile)
@@ -293,7 +293,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
 
         public void RejectChanges()
         {
-            ApplicationView.DispatchAsync(() => LoadFromProfile(Model));
+            ApplicationView.ExecuteOnUiThreadAsync(() => LoadFromProfile(Model));
         }
 
         #endregion Methods

--- a/FluentTerminal.App.ViewModels/Profiles/ProfileProviderViewModelBase.cs
+++ b/FluentTerminal.App.ViewModels/Profiles/ProfileProviderViewModelBase.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Web;
+using Windows.UI.Core;
 using FluentTerminal.App.Services;
 using FluentTerminal.Models;
 using FluentTerminal.Models.Enums;
@@ -214,7 +215,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
                 return;
             }
 
-            ApplicationView.RunOnDispatcherThread(() =>
+            ApplicationView.DispatchAsync(() =>
             {
                 TerminalThemes.Remove(theme);
 
@@ -222,12 +223,12 @@ namespace FluentTerminal.App.ViewModels.Profiles
                 {
                     SelectedTerminalTheme = TerminalThemes.First();
                 }
-            }, false);
+            }, CoreDispatcherPriority.Low, true);
         }
 
         private void OnThemeAdded(ThemeAddedMessage message)
         {
-            ApplicationView.RunOnDispatcherThread(() => TerminalThemes.Add(message.Theme), false);
+            ApplicationView.DispatchAsync(() => TerminalThemes.Add(message.Theme), CoreDispatcherPriority.Low, true);
         }
 
         private void Initialize(ShellProfile profile)
@@ -292,7 +293,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
 
         public void RejectChanges()
         {
-            ApplicationView.RunOnDispatcherThread(() => LoadFromProfile(Model), false);
+            ApplicationView.DispatchAsync(() => LoadFromProfile(Model));
         }
 
         #endregion Methods

--- a/FluentTerminal.App.ViewModels/Profiles/SshConnectViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Profiles/SshConnectViewModel.cs
@@ -155,7 +155,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
 
                     if (string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(username))
                     {
-                        ApplicationView.RunOnDispatcherThread(() => Username = username, false);
+                        ApplicationView.DispatchAsync(() => Username = username);
                     }
                 }, TaskContinuationOptions.OnlyOnRanToCompletion);
             }

--- a/FluentTerminal.App.ViewModels/Profiles/SshConnectViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Profiles/SshConnectViewModel.cs
@@ -155,7 +155,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
 
                     if (string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(username))
                     {
-                        ApplicationView.DispatchAsync(() => Username = username);
+                        ApplicationView.ExecuteOnUiThreadAsync(() => Username = username);
                     }
                 }, TaskContinuationOptions.OnlyOnRanToCompletion);
             }

--- a/FluentTerminal.App.ViewModels/Settings/AboutPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/AboutPageViewModel.cs
@@ -65,7 +65,7 @@ namespace FluentTerminal.App.ViewModels.Settings
         public async Task CheckForUpdate(bool notifyNoUpdate)
         {
             var version = ConvertVersionToString(await _updateService.GetLatestVersionAsync());
-            await _applicationView.RunOnDispatcherThread(() => LatestVersion = version);
+            await _applicationView.DispatchAsync(() => LatestVersion = version);
             await _updateService.CheckForUpdate(notifyNoUpdate);
         }
 

--- a/FluentTerminal.App.ViewModels/Settings/AboutPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/AboutPageViewModel.cs
@@ -65,7 +65,7 @@ namespace FluentTerminal.App.ViewModels.Settings
         public async Task CheckForUpdate(bool notifyNoUpdate)
         {
             var version = ConvertVersionToString(await _updateService.GetLatestVersionAsync());
-            await _applicationView.DispatchAsync(() => LatestVersion = version);
+            await _applicationView.ExecuteOnUiThreadAsync(() => LatestVersion = version);
             await _updateService.CheckForUpdate(notifyNoUpdate);
         }
 

--- a/FluentTerminal.App.ViewModels/TerminalViewModel.cs
+++ b/FluentTerminal.App.ViewModels/TerminalViewModel.cs
@@ -455,24 +455,25 @@ namespace FluentTerminal.App.ViewModels
             DuplicateTabRequested?.Invoke(this, EventArgs.Empty);
         }
 
-        private async void OnApplicationSettingsChanged(ApplicationSettingsChangedMessage message)
+        private void OnApplicationSettingsChanged(ApplicationSettingsChangedMessage message)
         {
-            await ApplicationView.DispatchAsync(() =>
+            ApplicationSettings = message.ApplicationSettings;
+
+            ApplicationView.ExecuteOnUiThreadAsync(() =>
             {
-                ApplicationSettings = message.ApplicationSettings;
                 RaisePropertyChanged(nameof(IsUnderlined));
                 RaisePropertyChanged(nameof(BackgroundTabTheme));
             });
         }
 
-        private async void OnCurrentThemeChanged(CurrentThemeChangedMessage message)
+        private void OnCurrentThemeChanged(CurrentThemeChangedMessage message)
         {
             // only change theme if not overwritten by profile
             if (ShellProfile.TerminalThemeId == Guid.Empty)
             {
                 var currentTheme = SettingsService.GetTheme(message.ThemeId);
 
-                await ApplicationView.DispatchAsync(() =>
+                ApplicationView.ExecuteOnUiThreadAsync(() =>
                 {
                     TerminalTheme = currentTheme;
                     ThemeChanged?.Invoke(this, currentTheme);
@@ -498,7 +499,7 @@ namespace FluentTerminal.App.ViewModels
                 tracker.SetInvalid();
             }
 
-            ApplicationView.DispatchAsync(() => HasExitedWithError = exitCode > 0);
+            ApplicationView.ExecuteOnUiThreadAsync(() => HasExitedWithError = exitCode > 0);
         }
 
         private void Terminal_Closed(object sender, EventArgs e)
@@ -568,7 +569,7 @@ namespace FluentTerminal.App.ViewModels
 
             if (!IsSelected && ApplicationSettings.ShowNewOutputIndicator)
             {
-                ApplicationView.DispatchAsync(() => HasNewOutput = true);
+                ApplicationView.ExecuteOnUiThreadAsync(() => HasNewOutput = true);
             }
         }
 

--- a/FluentTerminal.App.ViewModels/TerminalViewModel.cs
+++ b/FluentTerminal.App.ViewModels/TerminalViewModel.cs
@@ -457,7 +457,7 @@ namespace FluentTerminal.App.ViewModels
 
         private async void OnApplicationSettingsChanged(ApplicationSettingsChangedMessage message)
         {
-            await ApplicationView.RunOnDispatcherThread(() =>
+            await ApplicationView.DispatchAsync(() =>
             {
                 ApplicationSettings = message.ApplicationSettings;
                 RaisePropertyChanged(nameof(IsUnderlined));
@@ -467,16 +467,17 @@ namespace FluentTerminal.App.ViewModels
 
         private async void OnCurrentThemeChanged(CurrentThemeChangedMessage message)
         {
-            await ApplicationView.RunOnDispatcherThread(() =>
+            // only change theme if not overwritten by profile
+            if (ShellProfile.TerminalThemeId == Guid.Empty)
             {
-                // only change theme if not overwritten by profile
-                if (ShellProfile.TerminalThemeId == Guid.Empty)
+                var currentTheme = SettingsService.GetTheme(message.ThemeId);
+
+                await ApplicationView.DispatchAsync(() =>
                 {
-                    var currentTheme = SettingsService.GetTheme(message.ThemeId);
                     TerminalTheme = currentTheme;
                     ThemeChanged?.Invoke(this, currentTheme);
-                }
-            });
+                });
+            }
         }
 
         private void OnTerminalOptionsChanged(TerminalOptionsChangedMessage message)
@@ -497,13 +498,12 @@ namespace FluentTerminal.App.ViewModels
                 tracker.SetInvalid();
             }
 
-            ApplicationView.RunOnDispatcherThread(() => HasExitedWithError = exitCode > 0);
+            ApplicationView.DispatchAsync(() => HasExitedWithError = exitCode > 0);
         }
 
         private void Terminal_Closed(object sender, EventArgs e)
         {
-            ApplicationView.RunOnDispatcherThread(() => Closed?.Invoke(this, EventArgs.Empty));
-
+            Closed?.Invoke(this, EventArgs.Empty);
             Terminal.KeyboardCommandReceived -= Terminal_KeyboardCommandReceived;
             Terminal.OutputReceived -= Terminal_OutputReceived;
             Terminal.SizeChanged -= Terminal_SizeChanged;
@@ -568,7 +568,7 @@ namespace FluentTerminal.App.ViewModels
 
             if (!IsSelected && ApplicationSettings.ShowNewOutputIndicator)
             {
-                ApplicationView.RunOnDispatcherThread(() => HasNewOutput = true);
+                ApplicationView.DispatchAsync(() => HasNewOutput = true);
             }
         }
 

--- a/FluentTerminal.App/Adapters/ApplicationViewAdapter.cs
+++ b/FluentTerminal.App/Adapters/ApplicationViewAdapter.cs
@@ -7,6 +7,7 @@ using Windows.Foundation.Metadata;
 using Windows.UI.Core;
 using Windows.UI.Core.Preview;
 using Windows.UI.ViewManagement;
+using FluentTerminal.App.Utilities;
 
 namespace FluentTerminal.App.Adapters
 {
@@ -59,6 +60,12 @@ namespace FluentTerminal.App.Adapters
 
             return _dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => action()).AsTask();
         }
+
+        public Task DispatchAsync(Action action, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal,
+            bool enforceNewSchedule = false) => _dispatcher.ExecuteAsync(action, priority, enforceNewSchedule);
+
+        public Task<T> DispatchAsync<T>(Func<T> func, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal,
+            bool enforceNewSchedule = false) => _dispatcher.ExecuteAsync(func, priority, enforceNewSchedule);
 
         public async Task<bool> TryClose()
         {

--- a/FluentTerminal.App/Adapters/ApplicationViewAdapter.cs
+++ b/FluentTerminal.App/Adapters/ApplicationViewAdapter.cs
@@ -61,10 +61,10 @@ namespace FluentTerminal.App.Adapters
             return _dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => action()).AsTask();
         }
 
-        public Task DispatchAsync(Action action, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal,
+        public Task ExecuteOnUiThreadAsync(Action action, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal,
             bool enforceNewSchedule = false) => _dispatcher.ExecuteAsync(action, priority, enforceNewSchedule);
 
-        public Task<T> DispatchAsync<T>(Func<T> func, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal,
+        public Task<T> ExecuteOnUiThreadAsync<T>(Func<T> func, CoreDispatcherPriority priority = CoreDispatcherPriority.Normal,
             bool enforceNewSchedule = false) => _dispatcher.ExecuteAsync(func, priority, enforceNewSchedule);
 
         public async Task<bool> TryClose()

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -699,7 +699,7 @@ namespace FluentTerminal.App
             int viewId = viewModel.ApplicationView.Id;
             if (viewSwitcher != null)
             {
-                await viewModel.ApplicationView.DispatchAsync(async () => await viewSwitcher.ShowAsStandaloneAsync(viewId));
+                await viewModel.ApplicationView.ExecuteOnUiThreadAsync(async () => await viewSwitcher.ShowAsStandaloneAsync(viewId));
             }
             else
             {

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -699,7 +699,7 @@ namespace FluentTerminal.App
             int viewId = viewModel.ApplicationView.Id;
             if (viewSwitcher != null)
             {
-                await viewModel.ApplicationView.RunOnDispatcherThread(async () => await viewSwitcher.ShowAsStandaloneAsync(viewId));
+                await viewModel.ApplicationView.DispatchAsync(async () => await viewSwitcher.ShowAsStandaloneAsync(viewId));
             }
             else
             {

--- a/FluentTerminal.App/FluentTerminal.App.csproj
+++ b/FluentTerminal.App/FluentTerminal.App.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Services\AcceleratorKeyValidator.cs" />
     <Compile Include="Services\CommandHistoryService.cs" />
     <Compile Include="Utilities\DelayedAction.cs" />
+    <Compile Include="Utilities\DispatcherExtensions.cs" />
     <Compile Include="Utilities\InteractiveSurface.cs" />
     <Compile Include="ViewModels\CommandItemViewModel.cs" />
     <Compile Include="Dialogs\CustomCommandDialog.xaml.cs">

--- a/FluentTerminal.App/Utilities/DispatcherExtensions.cs
+++ b/FluentTerminal.App/Utilities/DispatcherExtensions.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading.Tasks;
+using Windows.UI.Core;
+
+namespace FluentTerminal.App.Utilities
+{
+    internal static class DispatcherExtensions
+    {
+        internal static Task ExecuteAsync(this CoreDispatcher dispatcher, Action action,
+            CoreDispatcherPriority priority = CoreDispatcherPriority.Normal, bool enforceNewSchedule = false)
+        {
+            if (enforceNewSchedule || !dispatcher.HasThreadAccess)
+            {
+                return dispatcher.RunAsync(priority, () => action()).AsTask();
+            }
+
+            action();
+
+            return Task.CompletedTask;
+        }
+
+        internal static Task<T> ExecuteAsync<T>(this CoreDispatcher dispatcher, Func<T> func,
+            CoreDispatcherPriority priority = CoreDispatcherPriority.Normal, bool enforceNewSchedule = false)
+        {
+            if (!enforceNewSchedule && dispatcher.HasThreadAccess)
+            {
+                return Task.FromResult(func());
+            }
+
+            var tcs = new TaskCompletionSource<T>();
+
+            var unused = dispatcher.RunAsync(priority, () =>
+            {
+                T val;
+
+                try
+                {
+                    val = func();
+                }
+                catch (Exception e)
+                {
+                    tcs.TrySetException(e);
+
+                    return;
+                }
+
+                tcs.TrySetResult(val);
+            });
+
+            return tcs.Task;
+        }
+    }
+}

--- a/FluentTerminal.App/ViewModels/CommandProfileProviderViewModel.cs
+++ b/FluentTerminal.App/ViewModels/CommandProfileProviderViewModel.cs
@@ -322,7 +322,7 @@ namespace FluentTerminal.App.ViewModels
                 }
             }
 
-            return ApplicationView.DispatchAsync(() => {
+            return ApplicationView.ExecuteOnUiThreadAsync(() => {
 
                 foreach (var command in toCheck)
                 {
@@ -358,7 +358,7 @@ namespace FluentTerminal.App.ViewModels
         {
             _historyService.Delete(command);
 
-            CommandItemViewModel toRemove = _allCommands.FirstOrDefault(c =>
+            var toRemove = _allCommands.FirstOrDefault(c =>
                 string.Equals(c.ExecutedCommand.Value, command.Value, StringComparison.Ordinal));
 
             if (toRemove != null)

--- a/FluentTerminal.App/ViewModels/CommandProfileProviderViewModel.cs
+++ b/FluentTerminal.App/ViewModels/CommandProfileProviderViewModel.cs
@@ -322,7 +322,7 @@ namespace FluentTerminal.App.ViewModels
                 }
             }
 
-            return ApplicationView.RunOnDispatcherThread(() => {
+            return ApplicationView.DispatchAsync(() => {
 
                 foreach (var command in toCheck)
                 {
@@ -351,7 +351,7 @@ namespace FluentTerminal.App.ViewModels
                         Commands.RemoveAt(index);
                     }
                 }
-            }, false);
+            });
         }
 
         public void RemoveCommand(ExecutedCommand command)

--- a/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
@@ -376,7 +376,7 @@ namespace FluentTerminal.App.Views
             ViewModel.Terminal.OutputReceived -= Terminal_OutputReceived;
             ViewModel.Terminal.RegisterSelectedTextCallback(null);
             _mediatorTaskCTSource.Cancel();
-            await ViewModel.ApplicationView.RunOnDispatcherThread(() =>
+            await ViewModel.ApplicationView.DispatchAsync(() =>
             {
                 _webView.NavigationCompleted -= _webView_NavigationCompleted;
                 _webView.NavigationStarting -= _webView_NavigationStarting;

--- a/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
@@ -370,13 +370,14 @@ namespace FluentTerminal.App.Views
             }, TaskCreationOptions.LongRunning);
         }
 
-        private async void Terminal_Closed(object sender, EventArgs e)
+        private void Terminal_Closed(object sender, EventArgs e)
         {
             ViewModel.Terminal.Closed -= Terminal_Closed;
             ViewModel.Terminal.OutputReceived -= Terminal_OutputReceived;
             ViewModel.Terminal.RegisterSelectedTextCallback(null);
             _mediatorTaskCTSource.Cancel();
-            await ViewModel.ApplicationView.DispatchAsync(() =>
+
+            ViewModel.ApplicationView.ExecuteOnUiThreadAsync(() =>
             {
                 _webView.NavigationCompleted -= _webView_NavigationCompleted;
                 _webView.NavigationStarting -= _webView_NavigationStarting;


### PR DESCRIPTION
**Merge https://github.com/felixse/FluentTerminal/pull/598 first**

Part of https://github.com/jumptrading/FluentTerminal/issues/238

The key reason for the change is removing `ManualResetEventSlim` and `SemaphoreSlim` which were used so far during the initialization of `XtermTerminalView`, and replacing them with much lighter `TaskCompletionSource` mechanism.