### PR TITLE
Minor changes in app menu implementation.

### DIFF
--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -699,6 +699,8 @@ namespace FluentTerminal.App.ViewModels
                 GetRecentMenuItems(), I18N.TranslateWithFallback("Recent_Description", "Recently opened sessions."),
                 icon: "\uF738" /*Segoe MDL2 Assets Glyph property*/));
 
+            appMenuViewModel.Items.Add(new SeparatorMenuItemViewModel());
+
             var settingsItem = new MenuItemViewModel(I18N.TranslateWithFallback("Settings.Text", "Settings"),
                 _settingsCommand, I18N.TranslateWithFallback("Settings_Description", "Opens settings window."),
                 icon: 57621 /*(int) Symbol.Setting*/);
@@ -714,7 +716,6 @@ namespace FluentTerminal.App.ViewModels
                 settingsItem.KeyBinding = null;
             }
 
-            appMenuViewModel.Items.Add(new SeparatorMenuItemViewModel());
             appMenuViewModel.Items.Add(settingsItem);
 
             appMenuViewModel.Items.Add(new MenuItemViewModel(I18N.TranslateWithFallback("AboutDialog.Title", "About"), _aboutCommand,

--- a/FluentTerminal.App.ViewModels/Menu/SeparatorMenuItemViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Menu/SeparatorMenuItemViewModel.cs
@@ -1,17 +1,15 @@
-﻿using System;
-
-namespace FluentTerminal.App.ViewModels.Menu
+﻿namespace FluentTerminal.App.ViewModels.Menu
 {
-    public class SeparatorMenuItemViewModel : MenuItemViewModelBase, IEquatable<SeparatorMenuItemViewModel>
+    public class SeparatorMenuItemViewModel : MenuItemViewModelBase
     {
         public SeparatorMenuItemViewModel()
             : base(string.Empty, string.Empty, null)
         {
         }
 
-        public bool Equals(SeparatorMenuItemViewModel other)
+        public override bool EquivalentTo(MenuItemViewModelBase other)
         {
-            return true;
+            return other is SeparatorMenuItemViewModel;
         }
     }
 }

--- a/FluentTerminal.App/Converters/MenuItemViewModelBaseToMenuFlayoutItemBaseConverter.cs
+++ b/FluentTerminal.App/Converters/MenuItemViewModelBaseToMenuFlayoutItemBaseConverter.cs
@@ -17,14 +17,27 @@ namespace FluentTerminal.App.Converters
 
         private static readonly IconConverter IconConverter = new IconConverter();
 
-        private static MenuFlyoutItemBase GetItem(MenuItemViewModelBase viewModel) =>
-            viewModel switch
+        private static MenuFlyoutItemBase GetItem(MenuItemViewModelBase viewModel)
+        {
+            if (viewModel is ExpandableMenuItemViewModel expandable)
             {
-                ExpandableMenuItemViewModel expandle => GetExpandableItem(expandle),
-                MenuItemViewModel regular => GetRegularItem(regular),
-                SeparatorMenuItemViewModel _ => GetSeparatorItem(),
-                _ => throw new NotImplementedException()
-            };
+                return GetExpandableItem(expandable);
+            }
+
+            if (viewModel is SeparatorMenuItemViewModel)
+            {
+                return GetSeparatorItem();
+            }
+
+            if (viewModel is MenuItemViewModel regular)
+            {
+                return GetRegularItem(regular);
+            }
+
+            // Won't happen ever, but still...
+            throw new NotImplementedException(
+                $"Unexpected {nameof(MenuItemViewModelBase)} type: {viewModel.GetType()}");
+        }
 
         private static MenuFlyoutSeparator GetSeparatorItem()
         {
@@ -64,12 +77,12 @@ namespace FluentTerminal.App.Converters
                 Mode = BindingMode.OneTime
             });
 
-            if (viewModel.KeyBinding is MenuItemKeyBindingViewModel keyBinding)
+            if (viewModel.KeyBinding != null)
             {
                 item.KeyboardAccelerators?.Add(new KeyboardAccelerator
                 {
-                    Key = (VirtualKey)keyBinding.Key,
-                    Modifiers = (VirtualKeyModifiers)keyBinding.KeyModifiers,
+                    Key = (VirtualKey) viewModel.KeyBinding.Key,
+                    Modifiers = (VirtualKeyModifiers) viewModel.KeyBinding.KeyModifiers,
                     IsEnabled = true
                 });
             }


### PR DESCRIPTION
Nice work with menu separator! Few fixes though:
- `SeparatorMenuItemViewModel` should override `EquivalentTo` method, not introduce `Equals`. Fixed.
- ReSharper doesn't support pattern matching in `switch` (thus causing me some troubles), so I've changed it to old-fashion `if` - `is` implementation.
- Minor reordering in `MainViewModel`.