### PR TITLE
Fixed a bug with keyboard shortcuts crushing the app

### DIFF
--- a/FluentTerminal.App.ViewModels/TerminalViewModel.cs
+++ b/FluentTerminal.App.ViewModels/TerminalViewModel.cs
@@ -541,16 +541,19 @@ namespace FluentTerminal.App.ViewModels
                     }
                 case nameof(Command.Search):
                     {
-                        ShowSearchPanel = !ShowSearchPanel;
-                        if (ShowSearchPanel)
+                        await ApplicationView.ExecuteOnUiThreadAsync(() =>
                         {
-                            SearchStarted?.Invoke(this, EventArgs.Empty);
-                        }
+                            ShowSearchPanel = !ShowSearchPanel;
+                            if (ShowSearchPanel)
+                            {
+                                SearchStarted?.Invoke(this, EventArgs.Empty);
+                            }
+                        });
                         break;
                     }
                 default:
                     {
-                        _keyboardCommandService.SendCommand(e);
+                        await ApplicationView.ExecuteOnUiThreadAsync(() => _keyboardCommandService.SendCommand(e));
                         break;
                     }
             }


### PR DESCRIPTION
Fixes the following bug: https://github.com/jumptrading/FluentTerminal/issues/246

This is another bug introduced by my latest PRs. To explain the reason: Earlier `XtermTerminalView.Terminal_KeyboardCommandReceived` method was always executed in the UI thread (it was called from one of the jobs from `_dispatcherJobs` collection). When removed the collection I didn't want to put all these jobs in UI thread (in order to offload it), but only those which actually require UI thread. So now the mentioned method is executed in some other thread, and I haven't changed that even in this fix. I've isolated only two parts from the whole method which are actually requiring the UI thread. The rest of the method works well without UI thread anyway.

Sorry for this one!