### PR TITLE
Overlay binding errors fixed

### DIFF
--- a/FluentTerminal.App.ViewModels/TerminalViewModel.cs
+++ b/FluentTerminal.App.ViewModels/TerminalViewModel.cs
@@ -157,7 +157,6 @@ namespace FluentTerminal.App.ViewModels
             TerminalView.DisposalPrepare();
             TerminalView = null;
             Terminal = null;
-            Overlay = null;
         }
 
         public event EventHandler Activated;
@@ -299,7 +298,7 @@ namespace FluentTerminal.App.ViewModels
 
         public Terminal Terminal { get; private set; }
 
-        public OverlayViewModel Overlay { get; private set; }
+        public OverlayViewModel Overlay { get; }
 
         public TerminalTheme TerminalTheme
         {

--- a/FluentTerminal.App/Converters/OverlayViewModelToOverlayViewConverter.cs
+++ b/FluentTerminal.App/Converters/OverlayViewModelToOverlayViewConverter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Windows.UI.Xaml.Data;
+using FluentTerminal.App.ViewModels;
+using FluentTerminal.App.Views;
+
+namespace FluentTerminal.App.Converters
+{
+    public class OverlayViewModelToOverlayViewConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            if (value == null)
+            {
+                return null;
+            }
+
+            if (value is OverlayViewModel overlayViewModel)
+            {
+                return new OverlayView(overlayViewModel);
+            }
+
+            // ReSharper disable once LocalizableElement
+            throw new ArgumentException(
+                $"Parameter {nameof(value)} is of type {value.GetType()}. Expected type: {typeof(OverlayViewModel)}.",
+                nameof(value));
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+            throw new NotSupportedException();
+    }
+}

--- a/FluentTerminal.App/FluentTerminal.App.csproj
+++ b/FluentTerminal.App/FluentTerminal.App.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Converters\I18NConverter.cs" />
     <Compile Include="Converters\IconConverter.cs" />
     <Compile Include="Converters\MenuItemViewModelBaseToMenuFlayoutItemBaseConverter.cs" />
+    <Compile Include="Converters\OverlayViewModelToOverlayViewConverter.cs" />
     <Compile Include="Converters\TabColorFallbackConverter.cs" />
     <Compile Include="Converters\EnumValueToVisibiltyConverter.cs" />
     <Compile Include="Converters\FalseToVisibleConverter.cs" />

--- a/FluentTerminal.App/Views/OverlayView.xaml
+++ b/FluentTerminal.App/Views/OverlayView.xaml
@@ -4,19 +4,18 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:viewModels="using:FluentTerminal.App.ViewModels"
     d:DesignHeight="300"
     d:DesignWidth="600"
+    d:DataContext="{d:DesignInstance viewModels:OverlayViewModel, IsDesignTimeCreatable=False}"
     mc:Ignorable="d"
     Visibility="{Binding ShowOverlay, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}">
     <Grid
-        Grid.Row="0"
         Margin="12"
-        Padding="6"
-        HorizontalAlignment="Right"
-        VerticalAlignment="Bottom">
+        Padding="6">
         <Grid.Background>
             <SolidColorBrush Color="{ThemeResource SystemAccentColor}" />
         </Grid.Background>
-        <TextBlock Foreground="White" Text="{Binding OverlayContent}" />
+        <TextBlock Foreground="White" Text="{Binding OverlayContent, Mode=OneWay}" />
     </Grid>
 </UserControl>

--- a/FluentTerminal.App/Views/OverlayView.xaml.cs
+++ b/FluentTerminal.App/Views/OverlayView.xaml.cs
@@ -1,11 +1,15 @@
 ﻿using Windows.UI.Xaml.Controls;
+using FluentTerminal.App.ViewModels;
 
 namespace FluentTerminal.App.Views
 {
+    // ReSharper disable once RedundantExtendsListEntry
     public sealed partial class OverlayView : UserControl
     {
-        public OverlayView()
+        public OverlayView(OverlayViewModel viewModel)
         {
+            DataContext = viewModel;
+
             InitializeComponent();
         }
     }

--- a/FluentTerminal.App/Views/TerminalView.xaml
+++ b/FluentTerminal.App/Views/TerminalView.xaml
@@ -5,9 +5,14 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:views="using:FluentTerminal.App.Views"
+    xmlns:converters="using:FluentTerminal.App.Converters"
     d:DesignHeight="300"
     d:DesignWidth="600"
     mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <converters:OverlayViewModelToOverlayViewConverter x:Key="OverlayViewModelToOverlayViewConverter"/>
+    </UserControl.Resources>
 
     <Grid>
         <Grid.RowDefinitions>
@@ -16,9 +21,10 @@
         </Grid.RowDefinitions>
         <Grid x:Name="TerminalContainer" Grid.Row="0" />
 
-        <views:OverlayView 
-            DataContext="{x:Bind ViewModel.Overlay}">
-        </views:OverlayView>
+        <ContentControl Grid.Row="0" 
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Bottom"
+                        Content="{x:Bind ViewModel.Overlay, Converter={StaticResource OverlayViewModelToOverlayViewConverter}}"/>
 
         <RelativePanel
             Grid.Row="1"

--- a/FluentTerminal.App/Views/TerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/TerminalView.xaml.cs
@@ -52,11 +52,9 @@ namespace FluentTerminal.App.Views
             ViewModel.ThemeChanged -= OnThemeChanged;
             ViewModel.FindNextRequested -= OnFindNextRequested;
             ViewModel.FindPreviousRequested -= OnFindPreviousRequested;
-
-            ViewModel = null;
         }
 
-        public TerminalViewModel ViewModel { get; private set; }
+        public TerminalViewModel ViewModel { get; }
 
         private void OnActivated(object sender, EventArgs e)
         {


### PR DESCRIPTION
Fixes https://github.com/jumptrading/FluentTerminal/issues/241

I'm still confused why we were getting these errors, but the only way for me to fix them was to inject `OverlayViewModel` through constructor to `OverlayView`. This change slightly improves complexity, but I strongly believe that it's better than leaving binding errors there. In my knowledge from WPF binding errors can significantly affect UI performances.