### PR TITLE
Resize and options changed delays reduced in XtermTerminalView

### DIFF
--- a/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
@@ -41,7 +41,7 @@ namespace FluentTerminal.App.Views
         #region Resize handling
 
         // Members related to resize handling
-        private static readonly TimeSpan ResizeDelay = TimeSpan.FromMilliseconds(200);
+        private static readonly TimeSpan ResizeDelay = TimeSpan.FromMilliseconds(60);
         private readonly object _resizeLock = new object();
         private TerminalSize _requestedSize;
         private TerminalSize _setSize;
@@ -150,7 +150,7 @@ namespace FluentTerminal.App.Views
             {
                 var serialized = JsonConvert.SerializeObject(options);
                 await ExecuteScriptAsync($"changeOptions('{serialized}')");
-            }, 200);
+            }, 100);
 
             _webView.Navigate(new Uri("ms-appx-web:///Client/index.html"));
         }


### PR DESCRIPTION
It's a trivial PR. As you can see in the code, I've only reduced delays in `XterTerminalView` in order to accomplish better responsiveness. I'm quite sure that the new delays are safe since they are kinda accumulating (action happens only after this period of silence). I've played with these values, and it looks great to me, yet safe. It's your call...