### PR TITLE
Hidding "Mosh Prots" in "SSH Info" dialog if "Use Mosh" isn't selected

### DIFF
--- a/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
+++ b/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
@@ -140,7 +140,7 @@
                         Margin="0,8,8,0"
                         VerticalAlignment="Center"
                         Text="Mosh ports:"
-                        Visibility="{x:Bind ViewModel.UseMosh, Converter={StaticResource TrueToVisibleConverter}}" />
+                        Visibility="{x:Bind ViewModel.UseMosh, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}" />
                     <TextBox
                         Grid.Row="0"
                         Grid.Column="1"
@@ -148,14 +148,14 @@
                         VerticalAlignment="Center"
                         BeforeTextChanging="Port_OnBeforeTextChanging"
                         Text="{x:Bind ViewModel.MoshPortFrom, Mode=TwoWay}"
-                        Visibility="{x:Bind ViewModel.UseMosh, Converter={StaticResource TrueToVisibleConverter}}" />
+                        Visibility="{x:Bind ViewModel.UseMosh, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}" />
                     <TextBlock
                         Grid.Row="0"
                         Grid.Column="2"
                         Margin="2,8,0,0"
                         VerticalAlignment="Center"
                         Text=":"
-                        Visibility="{x:Bind ViewModel.UseMosh, Converter={StaticResource TrueToVisibleConverter}}" />
+                        Visibility="{x:Bind ViewModel.UseMosh, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}" />
                     <TextBox
                         Grid.Row="0"
                         Grid.Column="3"
@@ -163,7 +163,7 @@
                         VerticalAlignment="Center"
                         BeforeTextChanging="Port_OnBeforeTextChanging"
                         Text="{x:Bind ViewModel.MoshPortTo, Mode=TwoWay}"
-                        Visibility="{x:Bind ViewModel.UseMosh, Converter={StaticResource TrueToVisibleConverter}}" />
+                        Visibility="{x:Bind ViewModel.UseMosh, Mode=OneWay, Converter={StaticResource TrueToVisibleConverter}}" />
 
                     <!--  Row  -->
                     <TextBlock


### PR DESCRIPTION
Fixes https://github.com/jumptrading/FluentTerminal/issues/248

@felixse, it looks that you've introduced this bug when moving from `Binding` and `DataContext` to `x:Bind` and `ViewModel` property. No matter this particular bug, I don't like it. Binding to `ViewModel` which is property of some object (in this case `SshInfoDialog`) which doesn't implement `INotifyPropertyChange` assumes some underlying overhead (how UI _knows_ that `ViewModel` property is changed if we haven't implemented `INotifyPropertyChanged`). Such bindings are source of [well known memory leaks in WPF](https://blog.jetbrains.com/dotnet/2014/09/04/fighting-common-wpf-memory-leaks-with-dotmemory/). Maybe things are better with UWP apps, but I would rather rely on my `INotifyPropertyChanged` implementation than put effort to the underlying infrastructure to _listen_ if property changed or not.

Anyway, it was just my opinion on the subject. This PR doesn't change that (as you can see).