### PR TITLE
Getting profiles from ISettingsService and optimizing JumpList

### DIFF
--- a/FluentTerminal.App.Services.Test/SettingsServiceTests.cs
+++ b/FluentTerminal.App.Services.Test/SettingsServiceTests.cs
@@ -38,7 +38,8 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(), 
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
 
             new SettingsService(defaultValueProvider.Object, applicationDataContainers);
@@ -60,6 +61,7 @@ namespace FluentTerminal.App.Services.Test
             var applicationDataContainers = new ApplicationDataContainers
             {
                 ShellProfiles = shellProfilesContainer.Object,
+                SshProfiles = Mock.Of<IApplicationDataContainer>(),
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
@@ -88,6 +90,7 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
@@ -113,6 +116,7 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider.Object, applicationDataContainers);
@@ -136,6 +140,7 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
@@ -157,6 +162,7 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>()
             };
             var currentThemeChangedEventInvoked = false;
@@ -181,7 +187,8 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
 
@@ -206,7 +213,8 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 RoamingSettings = roamingSettings.Object,
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
             Messenger.Default.Register<CurrentThemeChangedMessage>(this,
@@ -229,7 +237,8 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
 
@@ -251,7 +260,8 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
 
@@ -274,7 +284,8 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
 
@@ -297,7 +308,8 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
 
@@ -320,7 +332,8 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
 
@@ -342,7 +355,8 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
 
@@ -364,7 +378,8 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
             Messenger.Default.Register<TerminalOptionsChangedMessage>(this,
@@ -388,7 +403,8 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
 
@@ -410,7 +426,8 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
 
@@ -432,7 +449,8 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
             Messenger.Default.Register<ApplicationSettingsChangedMessage>(this,
@@ -459,7 +477,8 @@ namespace FluentTerminal.App.Services.Test
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
 
@@ -483,7 +502,8 @@ namespace FluentTerminal.App.Services.Test
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider.Object, applicationDataContainers);
 
@@ -508,7 +528,8 @@ namespace FluentTerminal.App.Services.Test
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
 
@@ -531,7 +552,8 @@ namespace FluentTerminal.App.Services.Test
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
             Messenger.Default.Register<KeyBindingsChangedMessage>(this,
@@ -553,7 +575,8 @@ namespace FluentTerminal.App.Services.Test
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider.Object, applicationDataContainers);
 
@@ -578,7 +601,8 @@ namespace FluentTerminal.App.Services.Test
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>(),
-                ShellProfiles = Mock.Of<IApplicationDataContainer>()
+                ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
             Messenger.Default.Register<KeyBindingsChangedMessage>(this,
@@ -602,6 +626,7 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
                 ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider, applicationDataContainers);
@@ -627,6 +652,7 @@ namespace FluentTerminal.App.Services.Test
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
                 ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>(),
                 Themes = Mock.Of<IApplicationDataContainer>()
             };
             var settingsService = new SettingsService(defaultValueProvider.Object, applicationDataContainers);
@@ -648,6 +674,7 @@ namespace FluentTerminal.App.Services.Test
             var applicationDataContainers = new ApplicationDataContainers
             {
                 ShellProfiles = shellProfilesContainer.Object,
+                SshProfiles = Mock.Of<IApplicationDataContainer>(),
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
@@ -670,6 +697,7 @@ namespace FluentTerminal.App.Services.Test
             var applicationDataContainers = new ApplicationDataContainers
             {
                 ShellProfiles = shellProfilesContainer.Object,
+                SshProfiles = Mock.Of<IApplicationDataContainer>(),
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
@@ -691,6 +719,7 @@ namespace FluentTerminal.App.Services.Test
             var applicationDataContainers = new ApplicationDataContainers
             {
                 ShellProfiles = shellProfilesContainer.Object,
+                SshProfiles = Mock.Of<IApplicationDataContainer>(),
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
@@ -715,6 +744,7 @@ namespace FluentTerminal.App.Services.Test
             var applicationDataContainers = new ApplicationDataContainers
             {
                 ShellProfiles = shellProfilesContainer.Object,
+                SshProfiles = Mock.Of<IApplicationDataContainer>(),
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 RoamingSettings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = localSettings.Object,
@@ -743,6 +773,7 @@ namespace FluentTerminal.App.Services.Test
             var applicationDataContainers = new ApplicationDataContainers
             {
                 ShellProfiles = Mock.Of<IApplicationDataContainer>(),
+                SshProfiles = Mock.Of<IApplicationDataContainer>(),
                 KeyBindings = Mock.Of<IApplicationDataContainer>(),
                 LocalSettings = Mock.Of<IApplicationDataContainer>(),
                 RoamingSettings = roamingSettings.Object,

--- a/FluentTerminal.App.Services/ISettingsService.cs
+++ b/FluentTerminal.App.Services/ISettingsService.cs
@@ -17,6 +17,10 @@ namespace FluentTerminal.App.Services
         IDictionary<string, ICollection<KeyBinding>> GetCommandKeyBindings();
         IEnumerable<ShellProfile> GetShellProfiles();
         IEnumerable<SshProfile> GetSshProfiles();
+        /// <summary>
+        /// Returns union of <see cref="GetShellProfiles"/> and <see cref="GetSshProfiles"/>.
+        /// </summary>
+        IEnumerable<ShellProfile> GetAllProfiles();
         IEnumerable<TabTheme> GetTabThemes();
         TerminalOptions GetTerminalOptions();
         TerminalTheme GetTheme(Guid id);

--- a/FluentTerminal.App.Services/Implementation/MoshBackwardCompatibility.cs
+++ b/FluentTerminal.App.Services/Implementation/MoshBackwardCompatibility.cs
@@ -22,7 +22,6 @@ namespace FluentTerminal.App.Services.Implementation
         /// <summary>
         /// Checks if the profile contains obsolete mosh syntax, and changes it if it does.
         /// </summary>
-        /// <typeparam name="T">The type of the profile (<see cref="ShellProfile"/> or <see cref="SshProfile"/>).</typeparam>
         /// <param name="profile">The profile. Note that the method doesn't change the input profile at all, but creates and
         /// returns its clone if there's something to change.</param>
         /// <remarks>
@@ -36,7 +35,7 @@ namespace FluentTerminal.App.Services.Implementation
         /// as the input profile). It allows us to simply check if anything is changed by comparing the input and output
         /// profiles for reference equality.
         /// </returns>
-        public static T FixProfile<T>(T profile) where T : ShellProfile
+        public static ShellProfile FixProfile(ShellProfile profile)
         {
             // If there aren't any arguments, or if the profile isn't a mosh profile, there's nothing to do. Just return.
             if (string.IsNullOrWhiteSpace(profile.Arguments) || !IsMoshProfile(profile)) return profile;
@@ -89,7 +88,7 @@ namespace FluentTerminal.App.Services.Implementation
 
             newProfile.Arguments = arguments;
 
-            return (T) newProfile;
+            return newProfile;
         }
     }
 }

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -468,8 +468,8 @@ namespace FluentTerminal.App
             {
                 await InitializeLogger();
 
-                // TODO: Check the reason for such strange using of tasks!
-                Task.Run(async () => await JumpListHelper.Update(_settingsService.GetShellProfiles()));
+                // Fire-and-forget pattern
+                var unused = JumpListHelper.UpdateAsync(_settingsService);
 
                 var viewModel = _container.Resolve<MainViewModel>();
                 if (args.Arguments.StartsWith(JumpListHelper.ShellProfileFlag))
@@ -682,7 +682,8 @@ namespace FluentTerminal.App
 
         private void OnSettingsClosed(object sender, EventArgs e)
         {
-            Task.Run(async () => await JumpListHelper.Update(_settingsService.GetShellProfiles()));
+            // Fire-and-forget pattern
+            var unused = JumpListHelper.UpdateAsync(_settingsService);
             _settingsViewModel.Closed -= OnSettingsClosed;
             _settingsViewModel = null;
             _settingsWindowId = null;

--- a/FluentTerminal.App/Dialogs/ShellProfileSelectionDialog.xaml.cs
+++ b/FluentTerminal.App/Dialogs/ShellProfileSelectionDialog.xaml.cs
@@ -20,8 +20,7 @@ namespace FluentTerminal.App.Dialogs
 
         public ShellProfileSelectionDialog(ISettingsService settingsService)
         {
-            Profiles = new ObservableCollection<ShellProfile>(settingsService.GetShellProfiles()
-                .Union(settingsService.GetSshProfiles()).OrderBy(p => p.Name));
+            Profiles = new ObservableCollection<ShellProfile>(settingsService.GetAllProfiles().OrderBy(p => p.Name));
 
             SelectedProfile = Profiles.First();
 

--- a/FluentTerminal.App/Services/CommandHistoryService.cs
+++ b/FluentTerminal.App/Services/CommandHistoryService.cs
@@ -73,9 +73,6 @@ namespace FluentTerminal.App.Services
 
         #region Methods
 
-        private List<ShellProfile> GetAllProfiles() =>
-            _settingsService.GetSshProfiles().Union(_settingsService.GetShellProfiles()).ToList();
-
         private List<ExecutedCommand> GetRawHistory(Func<List<ShellProfile>> profilesProvider = null)
         {
             if (_history == null)
@@ -176,7 +173,7 @@ namespace FluentTerminal.App.Services
                 return;
             }
 
-            var profiles = profilesProvider?.Invoke() ?? GetAllProfiles();
+            var profiles = profilesProvider?.Invoke() ?? _settingsService.GetAllProfiles().ToList();
 
             for (var i = 0; i < _history.Count; i++)
             {
@@ -219,7 +216,8 @@ namespace FluentTerminal.App.Services
         private IEnumerable<ExecutedCommand> GetHistory(bool byNumberOfUsages, bool includeProfiles,
             Func<List<ShellProfile>> profilesProvider = null)
         {
-            var allProfiles = new Lazy<List<ShellProfile>>(profilesProvider ?? GetAllProfiles);
+            var allProfiles =
+                new Lazy<List<ShellProfile>>(profilesProvider ?? (() => _settingsService.GetAllProfiles().ToList()));
 
             var history = GetRawHistory(() => allProfiles.Value);
 
@@ -306,7 +304,7 @@ namespace FluentTerminal.App.Services
 
                 existing = new ExecutedCommand {Value = profile.Name};
 
-                if (GetAllProfiles().Any(p => p.Id.Equals(profile.Id)))
+                if (_settingsService.GetAllProfiles().Any(p => p.Id.Equals(profile.Id)))
                 {
                     existing.ProfileId = profile.Id;
                 }

--- a/FluentTerminal.App/Utilities/JumpListHelper.cs
+++ b/FluentTerminal.App/Utilities/JumpListHelper.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using FluentTerminal.Models;
 using Windows.UI.StartScreen;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentTerminal.App.Services;
 
@@ -11,22 +9,24 @@ namespace FluentTerminal.App.Utilities
     {
         public const string ShellProfileFlag = "JumpList-ShellProfile-";
 
-        public static async Task Update(IEnumerable<ShellProfile> profiles)
+        public static async Task UpdateAsync(ISettingsService settingsService)
         {
+            if (!JumpList.IsSupported())
+            {
+                return;
+            }
+
             try
             {
-                if (JumpList.IsSupported())
+                var jumpList = await JumpList.LoadCurrentAsync();
+                jumpList.Items.Clear();
+                foreach (var profile in settingsService.GetAllProfiles())
                 {
-                    var jumpList = await JumpList.LoadCurrentAsync();
-                    jumpList.Items.Clear();
-                    foreach (var profile in profiles)
-                    {
-                        var item = JumpListItem.CreateWithArguments(ShellProfileFlag + profile.Id.ToString(), profile.Name);
-                        item.Description = profile.Location;
-                        jumpList.Items.Add(item);
-                    }
-                    await jumpList.SaveAsync();
+                    var item = JumpListItem.CreateWithArguments(ShellProfileFlag + profile.Id, profile.Name);
+                    item.Description = profile.Location;
+                    jumpList.Items.Add(item);
                 }
+                await jumpList.SaveAsync();
             }
             catch (Exception e)
             {

--- a/FluentTerminal.SystemTray/Program.cs
+++ b/FluentTerminal.SystemTray/Program.cs
@@ -48,6 +48,7 @@ namespace FluentTerminal.SystemTray
                     RoamingSettings = new ApplicationDataContainerAdapter(ApplicationData.Current.RoamingSettings),
                     KeyBindings = new ApplicationDataContainerAdapter(ApplicationData.Current.RoamingSettings.CreateContainer(Constants.KeyBindingsContainerName, ApplicationDataCreateDisposition.Always)),
                     ShellProfiles = new ApplicationDataContainerAdapter(ApplicationData.Current.LocalSettings.CreateContainer(Constants.ShellProfilesContainerName, ApplicationDataCreateDisposition.Always)),
+                    SshProfiles = new ApplicationDataContainerAdapter(ApplicationData.Current.RoamingSettings.CreateContainer(Constants.SshProfilesContainerName, ApplicationDataCreateDisposition.Always)),
                     Themes = new ApplicationDataContainerAdapter(ApplicationData.Current.RoamingSettings.CreateContainer(Constants.ThemesContainerName, ApplicationDataCreateDisposition.Always))
                 };
 


### PR DESCRIPTION
Related to https://github.com/jumptrading/FluentTerminal/issues/237

Suspicious `Task.Run...` call is removed, but it's already explained in details in https://github.com/jumptrading/FluentTerminal/issues/237#issuecomment-557353593. Here I need to explain why I've changed `GetShellProfiles` and `GetSshProfiles` methods in `SettingsService`:

Previously the methods were returning `List<ShellProfile>` and `List<SshProfile>`, although the method signature states that they return `IEnumerable<ShellProfile>` and `IEnumerable<SshProfile>`, respectively. The problem is that you don't have to return `List<T>` when you advertise it as `IEnumerable<T>`, especially no in cases when creating the list is expensive. The difference is that when returning `List<T>` you're always creating **the whole list, with all the items created**, while if you're returning `IEnumerable<T>`, you're actually creating and returning items one-by-one, and the calling code can break at any moment. It's important in our case because creating items is quite expensive (they are deserialized from JSON), and it's especially painful if there are many saved profiles.

Let's consider the following code:
```
var profile = _settingsService.GetShellProfiles().FirstOrDefault(p => p.Name.StartsWith("Power"));
```
If `GetShellProfile` returns `List<ShellProfile>`, then the whole list is created, and all saved profiles are deserialized. On the other side, if `GetShellProfile` returns `IEnumerable<ShellProfile>` (as the method signature advertises anyway), as soon as the match is found (in this case at the very first element) the call finishes, meaning that only one `ShellProfile` is deserialized.