### PR TITLE
Fixing async patterns in IThemeParser.

### DIFF
--- a/FluentTerminal.App.Services/Implementation/FluentTerminalThemeParser.cs
+++ b/FluentTerminal.App.Services/Implementation/FluentTerminalThemeParser.cs
@@ -9,16 +9,16 @@ namespace FluentTerminal.App.Services.Implementation
 {
     public class FluentTerminalThemeParser : IThemeParser
     {
-        public IEnumerable<string> SupportedFileTypes { get; } = new string[] { ".flutecolors" };
+        public IEnumerable<string> SupportedFileTypes { get; } = new[] { ".flutecolors" };
 
-        public async Task<ExportedTerminalTheme> Import(string fileName, Stream fileContent)
+        public Task<ExportedTerminalTheme> Import(string fileName, Stream fileContent)
         {
-            return await DeserializeTheme<ExportedTerminalTheme>(fileName, fileContent);
+            return DeserializeTheme<ExportedTerminalTheme>(fileName, fileContent);
         }
 
-        public async Task<TerminalTheme> Parse(string fileName, Stream fileContent)
+        public Task<TerminalTheme> Parse(string fileName, Stream fileContent)
         {
-            return await DeserializeTheme<TerminalTheme>(fileName, fileContent);
+            return DeserializeTheme<TerminalTheme>(fileName, fileContent);
         }
 
         public async Task<T> DeserializeTheme<T>(string fileName, Stream fileContent)

--- a/FluentTerminal.App.Services/Implementation/ITermThemeParser.cs
+++ b/FluentTerminal.App.Services/Implementation/ITermThemeParser.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
+// ReSharper disable InconsistentNaming
 
 namespace FluentTerminal.App.Services.Implementation
 {
@@ -14,7 +15,7 @@ namespace FluentTerminal.App.Services.Implementation
     {
         private const byte Opacity30Percent = 77;
 
-        public IEnumerable<string> SupportedFileTypes { get; } = new string[] { ".itermcolors" };
+        public IEnumerable<string> SupportedFileTypes { get; } = new[] { ".itermcolors" };
 
         private static class ITermThemeKeys
         {
@@ -36,7 +37,7 @@ namespace FluentTerminal.App.Services.Implementation
             public const string Ansi15Color = "Ansi 15 Color";
 
             public const string BackgroundColor = "Background Color";
-            public const string BoldColor = "Bold Color";
+            //public const string BoldColor = "Bold Color";
             public const string CursorColor = "Cursor Color";
             public const string CursorTextColor = "Cursor Text Color";
             public const string ForegroundColor = "Foreground Color";
@@ -134,7 +135,7 @@ namespace FluentTerminal.App.Services.Implementation
             return (alpha / 256.0).ToString(CultureInfo.InvariantCulture);
         }
 
-        public async Task<ExportedTerminalTheme> Import(string fileName, Stream fileContent)
+        public Task<ExportedTerminalTheme> Import(string fileName, Stream fileContent)
         {
             if (string.IsNullOrWhiteSpace(fileName))
             {
@@ -156,7 +157,7 @@ namespace FluentTerminal.App.Services.Implementation
                 PreInstalled = false
             };
 
-            return new ExportedTerminalTheme(terminalTheme, string.Empty);
+            return Task.FromResult(new ExportedTerminalTheme(terminalTheme, string.Empty));
         }
     }
 }


### PR DESCRIPTION
Related to https://github.com/jumptrading/FluentTerminal/issues/237

I've isolated this in a separate PR just to explain some of the things I am changing, and the reason for the change. Changes I've made here are removing `async` keyword if it isn't actually needed. `async`/`await` construct makes compiler break down the method internally into few methods, thus introducing some overhead at compile and run time. The overhead isn't too big, but there's no reason to have it anyway, if `async` isn't needed in the first place.

Example 1, old code:
```
public async Task<ExportedTerminalTheme> Import(string fileName, Stream fileContent)
{
    return await DeserializeTheme<ExportedTerminalTheme>(fileName, fileContent);
}
```
New code:
```
public Task<ExportedTerminalTheme> Import(string fileName, Stream fileContent)
{
    return DeserializeTheme<ExportedTerminalTheme>(fileName, fileContent);
}
```
These two implementations have the same exact behavior, yet the second one avoids `async`. In short, such single-liners should be changed.

Example 2 was in `ITermThemeParser.Import()` method, where we had `async` keyword, although the method didn't contain any `await` keyword. We should use `async` only if `await` is needed.