### PR TITLE
Bug with env var names becoming lowercase fixed

### DIFF
--- a/FluentTerminal.App.Services/Adapters/ApplicationDataContainerAdapter.cs
+++ b/FluentTerminal.App.Services/Adapters/ApplicationDataContainerAdapter.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Windows.Storage;
+using FluentTerminal.App.Services.Utilities;
 
 namespace FluentTerminal.App.Services.Adapters
 {
@@ -56,7 +57,8 @@ namespace FluentTerminal.App.Services.Adapters
 
         public void WriteValueAsJson<T>(string name, T value)
         {
-            _applicationDataContainer.Values[name] = JsonConvert.SerializeObject(value);
+            _applicationDataContainer.Values[name] = JsonConvert.SerializeObject(value,
+                PreserveDictionaryKeyCaseContractResolver.SerializerSettings);
         }
     }
 }

--- a/FluentTerminal.App.Services/Implementation/SettingsService.cs
+++ b/FluentTerminal.App.Services/Implementation/SettingsService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using FluentTerminal.App.Services.Utilities;
 using FluentTerminal.Models.Messages;
 using GalaSoft.MvvmLight.Messaging;
 
@@ -80,7 +81,7 @@ namespace FluentTerminal.App.Services.Implementation
                 config.SshProfiles.Add(profile);
             }
 
-            return JsonConvert.SerializeObject(config);
+            return JsonConvert.SerializeObject(config, PreserveDictionaryKeyCaseContractResolver.SerializerSettings);
         }
 
         public void ImportSettings(string serializedSettings)

--- a/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
+++ b/FluentTerminal.App.Services/Implementation/TrayProcessCommunicationService.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Windows.Foundation.Collections;
+using FluentTerminal.App.Services.Utilities;
 
 namespace FluentTerminal.App.Services.Implementation
 {
@@ -25,7 +26,8 @@ namespace FluentTerminal.App.Services.Implementation
             return new ValueSet
             {
                 [MessageKeys.Type] = content.Identifier,
-                [MessageKeys.Content] = JsonConvert.SerializeObject(content)
+                [MessageKeys.Content] = JsonConvert.SerializeObject(content,
+                    PreserveDictionaryKeyCaseContractResolver.SerializerSettings)
             };
         }
 

--- a/FluentTerminal.App.Services/Utilities/PreserveDictionaryKeyCaseContractResolver.cs
+++ b/FluentTerminal.App.Services/Utilities/PreserveDictionaryKeyCaseContractResolver.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace FluentTerminal.App.Services.Utilities
+{
+    public class PreserveDictionaryKeyCaseContractResolver : DefaultContractResolver
+    {
+        public static readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings
+            { ContractResolver = new PreserveDictionaryKeyCaseContractResolver() };
+
+        protected override JsonDictionaryContract CreateDictionaryContract(Type objectType)
+        {
+            var contract = base.CreateDictionaryContract(objectType);
+
+            contract.DictionaryKeyResolver = key => key;
+
+            return contract;
+        }
+    }
+}

--- a/FluentTerminal.App.Services/Utilities/TerminalThemeContractResolver.cs
+++ b/FluentTerminal.App.Services/Utilities/TerminalThemeContractResolver.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 
 namespace FluentTerminal.App.Services.Utilities
 {
-    public class TerminalThemeContractResolver : DefaultContractResolver
+    public class TerminalThemeContractResolver : PreserveDictionaryKeyCaseContractResolver
     {
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {


### PR DESCRIPTION
Solves https://github.com/jumptrading/FluentTerminal/issues/261

Surprisingly for me, it turned out that `JsonConvert.SerializeObject`, with default settings **changes dictionary keys to lowercase!** I cannot believe that NewtonSoft JSON did such dumb mistake!