### PR TITLE
async / await pattern improved in FluentTerminal.App.ViewModels project

### DIFF
--- a/FluentTerminal.App.Services/IClipboardService.cs
+++ b/FluentTerminal.App.Services/IClipboardService.cs
@@ -4,7 +4,7 @@ namespace FluentTerminal.App.Services
 {
     public interface IClipboardService
     {
-        Task<string> GetText();
+        Task<string> GetTextAsync();
 
         void SetText(string text);
     }

--- a/FluentTerminal.App.Services/IFileSystemService.cs
+++ b/FluentTerminal.App.Services/IFileSystemService.cs
@@ -6,12 +6,12 @@ namespace FluentTerminal.App.Services
 {
     public interface IFileSystemService
     {
-        Task<File> OpenFile(IEnumerable<string> fileTypes);
+        Task<File> OpenFileAsync(IEnumerable<string> fileTypes);
 
-        Task<string> BrowseForDirectory();
+        Task<string> BrowseForDirectoryAsync();
 
-        Task SaveTextFile(string name, string fileTypeDescription, string fileType, string content);
+        Task SaveTextFileAsync(string name, string fileTypeDescription, string fileType, string content);
 
-        Task<ImageFile> SaveImageInRoaming(ImageFile imageFile);
+        Task<ImageFile> SaveImageInRoamingAsync(ImageFile imageFile);
     }
 }

--- a/FluentTerminal.App.Services/IStartupTaskService.cs
+++ b/FluentTerminal.App.Services/IStartupTaskService.cs
@@ -5,8 +5,8 @@ namespace FluentTerminal.App.Services
 {
     public interface IStartupTaskService
     {
-        Task DisableStartupTask();
-        Task<StartupTaskStatus> EnableStartupTask();
-        Task<StartupTaskStatus> GetStatus();
+        Task DisableStartupTaskAsync();
+        Task<StartupTaskStatus> EnableStartupTaskAsync();
+        Task<StartupTaskStatus> GetStatusAsync();
     }
 }

--- a/FluentTerminal.App.Services/IUpdateService.cs
+++ b/FluentTerminal.App.Services/IUpdateService.cs
@@ -5,7 +5,7 @@ namespace FluentTerminal.App.Services
 {
     public interface IUpdateService
     {
-        Task CheckForUpdate(bool notifyNoUpdate = false);
+        Task CheckForUpdateAsync(bool notifyNoUpdate = false);
         Version GetCurrentVersion();
         Task<Version> GetLatestVersionAsync();
     }

--- a/FluentTerminal.App.Services/Implementation/UpdateService.cs
+++ b/FluentTerminal.App.Services/Implementation/UpdateService.cs
@@ -17,7 +17,7 @@ namespace FluentTerminal.App.Services.Implementation
             _notificationService = notificationService;
         }
 
-        public async Task CheckForUpdate(bool notifyNoUpdate = false)
+        public async Task CheckForUpdateAsync(bool notifyNoUpdate = false)
         {
             var latest = await GetLatestVersionAsync();
             if (latest > GetCurrentVersion())

--- a/FluentTerminal.App.Services/Terminal.cs
+++ b/FluentTerminal.App.Services/Terminal.cs
@@ -75,16 +75,16 @@ namespace FluentTerminal.App.Services
         /// <summary>
         /// To be called by either view or viewmodel
         /// </summary>
-        public async Task Close()
+        public Task CloseAsync()
         {
             if (_exited)
             {
                 Closed?.Invoke(this, System.EventArgs.Empty);
-                return;
+                return Task.CompletedTask;
             }
             _closingFromUi = true;
             _trayProcessCommunicationService.UnsubscribeFromTerminalOutput(Id);
-            await _trayProcessCommunicationService.CloseTerminalAsync(Id).ConfigureAwait(true);
+            return _trayProcessCommunicationService.CloseTerminalAsync(Id);
         }
 
         /// <summary>

--- a/FluentTerminal.App.ViewModels/ITerminalView.cs
+++ b/FluentTerminal.App.ViewModels/ITerminalView.cs
@@ -6,16 +6,15 @@ namespace FluentTerminal.App.ViewModels
 {
     public interface ITerminalView : IDisposable
     {
-        Task ChangeTheme(TerminalTheme theme);
-        Task ChangeKeyBindings();
-        Task ChangeOptions(TerminalOptions options);
-        Task Initialize(TerminalViewModel viewModel);
+        Task ChangeThemeAsync(TerminalTheme theme);
+        Task ChangeKeyBindingsAsync();
+        Task ChangeOptionsAsync(TerminalOptions options);
+        Task InitializeAsync(TerminalViewModel viewModel);
         void DisposalPrepare();
-        Task FindNext(string searchText);
-        Task FindPrevious(string searchText);
-        Task FocusTerminal();
-        Task<string> SerializeXtermState();
-
+        Task FindNextAsync(string searchText);
+        Task FindPreviousAsync(string searchText);
+        Task FocusTerminalAsync();
+        Task<string> SerializeXtermStateAsync();
         Task PasteAsync(string text);
     }
 }

--- a/FluentTerminal.App.ViewModels/Infrastructure/AsyncCommand.cs
+++ b/FluentTerminal.App.ViewModels/Infrastructure/AsyncCommand.cs
@@ -35,6 +35,7 @@ namespace FluentTerminal.App.ViewModels.Infrastructure
             {
                 try
                 {
+                    // TODO: If we're using class field _isExecuting, maybe we should introduce some locking?
                     _isExecuting = true;
                     await _execute();
                 }

--- a/FluentTerminal.App.ViewModels/ProfileViewModelBase.cs
+++ b/FluentTerminal.App.ViewModels/ProfileViewModelBase.cs
@@ -101,9 +101,9 @@ namespace FluentTerminal.App.ViewModels
 
             Initialize(shellProfile);
 
-            DeleteCommand = new AsyncCommand(Delete, CanDelete);
+            DeleteCommand = new AsyncCommand(DeleteAsync, CanDelete);
             EditCommand = new RelayCommand(Edit);
-            CancelEditCommand = new AsyncCommand(CancelEdit);
+            CancelEditCommand = new AsyncCommand(CancelEditAsync);
             SaveChangesCommand = new AsyncCommand(SaveChangesAsync);
             AddKeyboardShortcutCommand = new AsyncCommand(AddKeyboardShortcut);
         }
@@ -133,10 +133,10 @@ namespace FluentTerminal.App.ViewModels
                 || !(_environmentVariablesBeforeEdit?.SequenceEqual(EnvironmentVariables.ToDictionary(x => x.Name, x => x.Value)) ?? false);
         }
 
-        private async Task Delete()
+        private async Task DeleteAsync()
         {
             var result = await DialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
-                I18N.Translate("ConfirmDeleteProfile"), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
+                I18N.Translate("ConfirmDeleteProfile"), DialogButton.OK, DialogButton.Cancel);
 
             if (result == DialogButton.OK)
             {
@@ -161,24 +161,23 @@ namespace FluentTerminal.App.ViewModels
             InEditMode = true;
         }
 
-        private async Task CancelEdit()
+        private async Task CancelEditAsync()
         {
             if (IsNew)
             {
-                await Delete();
+                await DeleteAsync();
             }
             else
             {
                 if (HasChanges())
                 {
                     var result = await DialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
-                            I18N.Translate("ConfirmDiscardChanges"), DialogButton.OK, DialogButton.Cancel)
-                        .ConfigureAwait(true);
+                            I18N.Translate("ConfirmDiscardChanges"), DialogButton.OK, DialogButton.Cancel);
 
                     if (result == DialogButton.OK)
                     {
                         // Cancelled, so rollback
-                        ProfileVm.RejectChanges();
+                        await ProfileVm.RejectChangesAsync();
 
                         KeyBindings.Editable = false;
                         InEditMode = false;
@@ -192,7 +191,7 @@ namespace FluentTerminal.App.ViewModels
             }
         }
 
-        public virtual async Task SaveChangesAsync()
+        private async Task SaveChangesAsync()
         {
             var error = await ProfileVm.AcceptChangesAsync();
 
@@ -240,7 +239,7 @@ namespace FluentTerminal.App.ViewModels
 
         public Task AddKeyboardShortcut()
         {
-            return KeyBindings.ShowAddKeyBindingDialog();
+            return KeyBindings.ShowAddKeyBindingDialogAsync();
         }
 
         #endregion Methods

--- a/FluentTerminal.App.ViewModels/Profiles/CommonProfileProviderViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Profiles/CommonProfileProviderViewModel.cs
@@ -90,7 +90,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
 
         protected override async Task CopyToProfileAsync(ShellProfile profile)
         {
-            await base.CopyToProfileAsync(profile);
+            await base.CopyToProfileAsync(profile).ConfigureAwait(false);
 
             profile.Location = _location;
             profile.Arguments = _arguments;
@@ -123,8 +123,10 @@ namespace FluentTerminal.App.ViewModels.Profiles
                    !Model.Arguments.NullableEqualTo(_arguments);
         }
 
+        // Requires UI thread
         private async Task BrowseForCustomShell()
         {
+            // ConfigureAwait(true) because we're setting some view-model properties afterwards.
             var file = await _fileSystemService.OpenFileAsync(new[] { ".exe" }).ConfigureAwait(true);
             if (file != null)
             {
@@ -132,8 +134,10 @@ namespace FluentTerminal.App.ViewModels.Profiles
             }
         }
 
+        // Requires UI thread
         private async Task BrowseForWorkingDirectory()
         {
+            // ConfigureAwait(true) because we're setting some view-model properties afterwards.
             var directory = await _fileSystemService.BrowseForDirectoryAsync().ConfigureAwait(true);
             if (directory != null)
             {

--- a/FluentTerminal.App.ViewModels/Profiles/CommonProfileProviderViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Profiles/CommonProfileProviderViewModel.cs
@@ -99,7 +99,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
 
         public override async Task<string> ValidateAsync()
         {
-            var error = await base.ValidateAsync();
+            var error = await base.ValidateAsync().ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(error))
             {
@@ -125,7 +125,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
 
         private async Task BrowseForCustomShell()
         {
-            var file = await _fileSystemService.OpenFile(new[] { ".exe" }).ConfigureAwait(true);
+            var file = await _fileSystemService.OpenFileAsync(new[] { ".exe" }).ConfigureAwait(true);
             if (file != null)
             {
                 Location = file.Path;
@@ -134,7 +134,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
 
         private async Task BrowseForWorkingDirectory()
         {
-            var directory = await _fileSystemService.BrowseForDirectory().ConfigureAwait(true);
+            var directory = await _fileSystemService.BrowseForDirectoryAsync().ConfigureAwait(true);
             if (directory != null)
             {
                 WorkingDirectory = directory;

--- a/FluentTerminal.App.ViewModels/Profiles/ProfileProviderViewModelBase.cs
+++ b/FluentTerminal.App.ViewModels/Profiles/ProfileProviderViewModelBase.cs
@@ -281,19 +281,19 @@ namespace FluentTerminal.App.ViewModels.Profiles
         /// message returned by <see cref="ValidateAsync"/> method.</returns>
         public async Task<string> AcceptChangesAsync(bool acceptIfInvalid = false)
         {
-            var error = await ValidateAsync();
+            var error = await ValidateAsync().ConfigureAwait(false);
 
             if (acceptIfInvalid || string.IsNullOrEmpty(error))
             {
-                await CopyToProfileAsync(Model);
+                await CopyToProfileAsync(Model).ConfigureAwait(false);
             }
 
             return error;
         }
 
-        public void RejectChanges()
+        public Task RejectChangesAsync()
         {
-            ApplicationView.ExecuteOnUiThreadAsync(() => LoadFromProfile(Model));
+            return ApplicationView.ExecuteOnUiThreadAsync(() => LoadFromProfile(Model));
         }
 
         #endregion Methods

--- a/FluentTerminal.App.ViewModels/Profiles/SshConnectViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Profiles/SshConnectViewModel.cs
@@ -166,9 +166,11 @@ namespace FluentTerminal.App.ViewModels.Profiles
             MoshPortTo = sshProfile.MoshPortTo;
         }
 
+        // Requires UI thread
         private async Task BrowseForIdentityFileAsync()
         {
-            var file = await _fileSystemService.OpenFileAsync(new[] { "*" });
+            // ConfigureAwait(true) because we're setting some view-model properties afterwards.
+            var file = await _fileSystemService.OpenFileAsync(new[] { "*" }).ConfigureAwait(true);
             if (file != null)
             {
                 IdentityFile = file.Path;
@@ -283,7 +285,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
                 result |= SshConnectionInfoValidationResult.SshPortZeroOrNegative;
             }
 
-            if (!await CheckIdentityFileExistsAsync())
+            if (!await CheckIdentityFileExistsAsync().ConfigureAwait(false))
             {
                 result |= SshConnectionInfoValidationResult.IdentityFileDoesNotExist;
             }
@@ -306,6 +308,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
             return result;
         }
 
+        // Requires UI thread
         private async Task<bool> CheckIdentityFileExistsAsync()
         {
             var identityFile = _identityFile;
@@ -325,7 +328,8 @@ namespace FluentTerminal.App.ViewModels.Profiles
             }
             else
             {
-                var sshConfigDir = await _trayProcessCommunicationService.GetSshConfigDirAsync();
+                // ConfigureAwait(true) because we're setting some view-model properties afterwards.
+                var sshConfigDir = await _trayProcessCommunicationService.GetSshConfigDirAsync().ConfigureAwait(true);
 
                 if (string.IsNullOrEmpty(sshConfigDir))
                 {
@@ -335,7 +339,8 @@ namespace FluentTerminal.App.ViewModels.Profiles
                 fullPath = Path.Combine(sshConfigDir, identityFile);
             }
 
-            if (await _trayProcessCommunicationService.CheckFileExistsAsync(fullPath))
+            // ConfigureAwait(true) because we're setting some view-model properties afterwards.
+            if (await _trayProcessCommunicationService.CheckFileExistsAsync(fullPath).ConfigureAwait(true))
             {
                 _validatedIdentityFile = identityFile;
 

--- a/FluentTerminal.App.ViewModels/Profiles/SshConnectViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Profiles/SshConnectViewModel.cs
@@ -132,7 +132,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
 
             Initialize((SshProfile)Model);
 
-            BrowseForIdentityFileCommand = new AsyncCommand(BrowseForIdentityFile);
+            BrowseForIdentityFileCommand = new AsyncCommand(BrowseForIdentityFileAsync);
         }
 
         #endregion Constructor
@@ -166,9 +166,9 @@ namespace FluentTerminal.App.ViewModels.Profiles
             MoshPortTo = sshProfile.MoshPortTo;
         }
 
-        private async Task BrowseForIdentityFile()
+        private async Task BrowseForIdentityFileAsync()
         {
-            var file = await _fileSystemService.OpenFile(new[] { "*" });
+            var file = await _fileSystemService.OpenFileAsync(new[] { "*" });
             if (file != null)
             {
                 IdentityFile = file.Path;
@@ -210,9 +210,9 @@ namespace FluentTerminal.App.ViewModels.Profiles
 
         protected override async Task CopyToProfileAsync(ShellProfile profile)
         {
-            await base.CopyToProfileAsync(profile);
+            await base.CopyToProfileAsync(profile).ConfigureAwait(false);
 
-            SshProfile sshProfile = (SshProfile) profile;
+            var sshProfile = (SshProfile) profile;
 
             sshProfile.Location = _useMosh ? Constants.MoshCommandName : Constants.SshCommandName;
             sshProfile.Arguments = GetArgumentsString();
@@ -230,14 +230,14 @@ namespace FluentTerminal.App.ViewModels.Profiles
 
         public override async Task<string> ValidateAsync()
         {
-            var error = await base.ValidateAsync();
+            var error = await base.ValidateAsync().ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(error))
             {
                 return error;
             }
 
-            var result = await GetSshInfoValidationResultAsync();
+            var result = await GetSshInfoValidationResultAsync().ConfigureAwait(false);
 
             if (result == SshConnectionInfoValidationResult.Valid)
             {
@@ -264,7 +264,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
                    original.MoshPortFrom != _moshPortFrom || original.MoshPortTo != _moshPortTo;
         }
 
-        public async Task<SshConnectionInfoValidationResult> GetSshInfoValidationResultAsync()
+        private async Task<SshConnectionInfoValidationResult> GetSshInfoValidationResultAsync()
         {
             var result = SshConnectionInfoValidationResult.Valid;
 
@@ -445,14 +445,14 @@ namespace FluentTerminal.App.ViewModels.Profiles
 
         public override async Task<Tuple<bool, string>> GetUrlAsync()
         {
-            var error = await base.ValidateAsync();
+            var error = await base.ValidateAsync().ConfigureAwait(false);
 
             if (!string.IsNullOrEmpty(error))
             {
                 return Tuple.Create(false, error);
             }
 
-            var result = await GetSshInfoValidationResultAsync();
+            var result = await GetSshInfoValidationResultAsync().ConfigureAwait(false);
 
             if (result != SshConnectionInfoValidationResult.Valid &&
                 // For links we can ignore missing username
@@ -469,7 +469,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
                 return Tuple.Create(false, error);
             }
 
-            StringBuilder sb = new StringBuilder(_useMosh ? MoshUriScheme : SshUriScheme);
+            var sb = new StringBuilder(_useMosh ? MoshUriScheme : SshUriScheme);
 
             sb.Append("://");
 

--- a/FluentTerminal.App.ViewModels/Settings/AboutPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/AboutPageViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using FluentTerminal.App.Services;
 using FluentTerminal.App.ViewModels.Infrastructure;
 using GalaSoft.MvvmLight;
-using System;
 using System.Threading.Tasks;
 
 namespace FluentTerminal.App.ViewModels.Settings
@@ -18,7 +17,7 @@ namespace FluentTerminal.App.ViewModels.Settings
             _updateService = updateService;
             _applicationView = applicationView;
 
-            CheckForUpdatesCommand = new AsyncCommand(() => CheckForUpdate(true));
+            CheckForUpdatesCommand = new AsyncCommand(() => CheckForUpdateAsync(true));
         }
 
         public IAsyncCommand CheckForUpdatesCommand { get; }
@@ -28,7 +27,7 @@ namespace FluentTerminal.App.ViewModels.Settings
             get
             {
                 var version = _updateService.GetCurrentVersion();
-                return ConvertVersionToString(version);
+                return $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}";
             }
         }
 
@@ -59,19 +58,14 @@ namespace FluentTerminal.App.ViewModels.Settings
 
         public Task OnNavigatedTo()
         {
-            return CheckForUpdate(false);
+            return CheckForUpdateAsync(false);
         }
 
-        public async Task CheckForUpdate(bool notifyNoUpdate)
+        private async Task CheckForUpdateAsync(bool notifyNoUpdate)
         {
-            var version = ConvertVersionToString(await _updateService.GetLatestVersionAsync());
-            await _applicationView.ExecuteOnUiThreadAsync(() => LatestVersion = version);
-            await _updateService.CheckForUpdate(notifyNoUpdate);
-        }
-
-        private string ConvertVersionToString(Version version)
-        {
-            return string.Format("{0}.{1}.{2}.{3}", version.Major, version.Minor, version.Build, version.Revision);
+            var version = await _updateService.GetLatestVersionAsync();
+            await _applicationView.ExecuteOnUiThreadAsync(() => LatestVersion = $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}");
+            await _updateService.CheckForUpdateAsync(notifyNoUpdate);
         }
     }
 }

--- a/FluentTerminal.App.ViewModels/Settings/AboutPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/AboutPageViewModel.cs
@@ -63,9 +63,11 @@ namespace FluentTerminal.App.ViewModels.Settings
 
         private async Task CheckForUpdateAsync(bool notifyNoUpdate)
         {
-            var version = await _updateService.GetLatestVersionAsync();
-            await _applicationView.ExecuteOnUiThreadAsync(() => LatestVersion = $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}");
-            await _updateService.CheckForUpdateAsync(notifyNoUpdate);
+            var version = await _updateService.GetLatestVersionAsync().ConfigureAwait(false);
+            await _applicationView.ExecuteOnUiThreadAsync(() =>
+                    LatestVersion = $"{version.Major}.{version.Minor}.{version.Build}.{version.Revision}")
+                .ConfigureAwait(false);
+            await _updateService.CheckForUpdateAsync(notifyNoUpdate).ConfigureAwait(false);
         }
     }
 }

--- a/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
@@ -61,9 +61,11 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
+        // Requires UI thread
         public async Task OnNavigatedToAsync()
         {
-            var startupTaskStatus = await _startupTaskService.GetStatusAsync();
+            // ConfigureAwait(true) because we want to execute SetStartupTaskPropertiesForStatus from the calling (UI) thread.
+            var startupTaskStatus = await _startupTaskService.GetStatusAsync().ConfigureAwait(true);
             SetStartupTaskPropertiesForStatus(startupTaskStatus);
         }
 
@@ -389,10 +391,13 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
+        // Requires UI thread
         private async Task RestoreDefaultsAsync()
         {
+            // ConfigureAwait(true) because we're setting some view-model properties afterwards
             var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
-                I18N.Translate("ConfirmRestoreGeneralSettings"), DialogButton.OK, DialogButton.Cancel);
+                    I18N.Translate("ConfirmRestoreGeneralSettings"), DialogButton.OK, DialogButton.Cancel)
+                .ConfigureAwait(true);
 
             if (result == DialogButton.OK)
             {
@@ -416,6 +421,7 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
+        // Requires UI thread
         private void SetStartupTaskPropertiesForStatus(StartupTaskStatus startupTaskStatus)
         {
             switch (startupTaskStatus)
@@ -452,24 +458,30 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
+        // Requires UI thread
         private async Task SetStartupTaskStateAsync(bool enabled)
         {
             StartupTaskStatus status;
             if (enabled)
             {
-                status = await _startupTaskService.EnableStartupTaskAsync();
+                // ConfigureAwait(true) because we need to execute SetStartupTaskPropertiesForStatus in the calling (UI) thread.
+                status = await _startupTaskService.EnableStartupTaskAsync().ConfigureAwait(true);
             }
             else
             {
-                await _startupTaskService.DisableStartupTaskAsync();
-                status = await _startupTaskService.GetStatusAsync();
+                // ConfigureAwait(true) because we need to execute SetStartupTaskPropertiesForStatus in the calling (UI) thread.
+                await _startupTaskService.DisableStartupTaskAsync().ConfigureAwait(true);
+                // ConfigureAwait(true) because we need to execute SetStartupTaskPropertiesForStatus in the calling (UI) thread.
+                status = await _startupTaskService.GetStatusAsync().ConfigureAwait(true);
             }
             SetStartupTaskPropertiesForStatus(status);
         }
 
+        // Requires UI thread
         private async Task BrowseLogDirectoryAsync()
         {
-            var folder = await _fileSystemService.BrowseForDirectoryAsync();
+            // ConfigureAwait(true) because we're setting some view-model properties afterwards.
+            var folder = await _fileSystemService.BrowseForDirectoryAsync().ConfigureAwait(true);
 
             if (folder != null)
             {

--- a/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/GeneralPageViewModel.cs
@@ -39,8 +39,8 @@ namespace FluentTerminal.App.ViewModels.Settings
 
             _applicationSettings = _settingsService.GetApplicationSettings();
 
-            RestoreDefaultsCommand = new AsyncCommand(RestoreDefaults);
-            BrowseLogDirectoryCommand = new AsyncCommand(BrowseLogDirectory);
+            RestoreDefaultsCommand = new AsyncCommand(RestoreDefaultsAsync);
+            BrowseLogDirectoryCommand = new AsyncCommand(BrowseLogDirectoryAsync);
         }
 
         public IEnumerable<string> Languages => _applicationLanguageService.Languages;
@@ -63,7 +63,7 @@ namespace FluentTerminal.App.ViewModels.Settings
 
         public async Task OnNavigatedToAsync()
         {
-            var startupTaskStatus = await _startupTaskService.GetStatus();
+            var startupTaskStatus = await _startupTaskService.GetStatusAsync();
             SetStartupTaskPropertiesForStatus(startupTaskStatus);
         }
 
@@ -389,9 +389,10 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
-        private async Task RestoreDefaults()
+        private async Task RestoreDefaultsAsync()
         {
-            var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"), I18N.Translate("ConfirmRestoreGeneralSettings"), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
+            var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
+                I18N.Translate("ConfirmRestoreGeneralSettings"), DialogButton.OK, DialogButton.Cancel);
 
             if (result == DialogButton.OK)
             {
@@ -456,19 +457,19 @@ namespace FluentTerminal.App.ViewModels.Settings
             StartupTaskStatus status;
             if (enabled)
             {
-                status = await _startupTaskService.EnableStartupTask();
+                status = await _startupTaskService.EnableStartupTaskAsync();
             }
             else
             {
-                await _startupTaskService.DisableStartupTask();
-                status = await _startupTaskService.GetStatus();
+                await _startupTaskService.DisableStartupTaskAsync();
+                status = await _startupTaskService.GetStatusAsync();
             }
             SetStartupTaskPropertiesForStatus(status);
         }
 
-        private async Task BrowseLogDirectory()
+        private async Task BrowseLogDirectoryAsync()
         {
-            var folder = await _fileSystemService.BrowseForDirectory();
+            var folder = await _fileSystemService.BrowseForDirectoryAsync();
 
             if (folder != null)
             {

--- a/FluentTerminal.App.ViewModels/Settings/KeyBindingViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/KeyBindingViewModel.cs
@@ -17,8 +17,8 @@ namespace FluentTerminal.App.ViewModels.Settings
             Model = keyBinding;
             Parent = parent;
             _dialogService = dialogService;
-            EditCommand = new AsyncCommand(Edit);
-            DeleteCommand = new AsyncCommand(Delete);
+            EditCommand = new AsyncCommand(EditAsync);
+            DeleteCommand = new AsyncCommand(DeleteAsync);
         }
 
         public event EventHandler Deleted;
@@ -97,9 +97,9 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
-        public async Task<bool> Edit()
+        public async Task<bool> EditAsync()
         {
-            var keyBinding = await _dialogService.ShowCreateKeyBindingDialog().ConfigureAwait(true);
+            var keyBinding = await _dialogService.ShowCreateKeyBindingDialog();
 
             if (keyBinding != null)
             {
@@ -117,9 +117,10 @@ namespace FluentTerminal.App.ViewModels.Settings
             return false;
         }
 
-        private async Task Delete()
+        private async Task DeleteAsync()
         {
-            var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"), I18N.Translate("ConfirmDeleteKeybindings"), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
+            var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
+                I18N.Translate("ConfirmDeleteKeybindings"), DialogButton.OK, DialogButton.Cancel);
 
             if (result == DialogButton.OK)
             {

--- a/FluentTerminal.App.ViewModels/Settings/KeyBindingViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/KeyBindingViewModel.cs
@@ -21,6 +21,7 @@ namespace FluentTerminal.App.ViewModels.Settings
             DeleteCommand = new AsyncCommand(DeleteAsync);
         }
 
+        // Needs to be triggered from the UI thread
         public event EventHandler Deleted;
 
         public event EventHandler Edited;
@@ -97,9 +98,11 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
+        // Requires UI thread
         public async Task<bool> EditAsync()
         {
-            var keyBinding = await _dialogService.ShowCreateKeyBindingDialog();
+            // ConfigureAwait(true) because we're setting some view-model properties afterwards.
+            var keyBinding = await _dialogService.ShowCreateKeyBindingDialog().ConfigureAwait(true);
 
             if (keyBinding != null)
             {
@@ -117,10 +120,12 @@ namespace FluentTerminal.App.ViewModels.Settings
             return false;
         }
 
+        // Requires UI thread
         private async Task DeleteAsync()
         {
+            // ConfigureAwait(true) because we need to trigger Deleted event in the calling (UI) thread.
             var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
-                I18N.Translate("ConfirmDeleteKeybindings"), DialogButton.OK, DialogButton.Cancel);
+                I18N.Translate("ConfirmDeleteKeybindings"), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
 
             if (result == DialogButton.OK)
             {

--- a/FluentTerminal.App.ViewModels/Settings/KeyBindingsPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/KeyBindingsPageViewModel.cs
@@ -38,6 +38,7 @@ namespace FluentTerminal.App.ViewModels.Settings
             return KeyBindings.First(k => k.Command == command).ShowAddKeyBindingDialogAsync();
         }
 
+        // Requires UI thread
         private void ClearKeyBindings()
         {
             foreach (var keyBinding in KeyBindings)
@@ -48,6 +49,7 @@ namespace FluentTerminal.App.ViewModels.Settings
             KeyBindings.Clear();
         }
 
+        // Requires UI thread
         private void Initialize(IDictionary<string, ICollection<KeyBinding>> keyBindings)
         {
             ClearKeyBindings();
@@ -71,10 +73,12 @@ namespace FluentTerminal.App.ViewModels.Settings
             _trayProcessCommunicationService.UpdateToggleWindowKeyBindingsAsync();
         }
 
+        // Requires UI thread
         private async Task RestoreDefaultsAsync()
         {
+            // ConfigureAwait(true) because we need to execute Initialize in the calling (UI) thread.
             var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
-                I18N.Translate("ConfirmRestoreKeybindings"), DialogButton.OK, DialogButton.Cancel);
+                I18N.Translate("ConfirmRestoreKeybindings"), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
 
             if (result == DialogButton.OK)
             {

--- a/FluentTerminal.App.ViewModels/Settings/KeyBindingsPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/KeyBindingsPageViewModel.cs
@@ -23,8 +23,8 @@ namespace FluentTerminal.App.ViewModels.Settings
             _settingsService = settingsService;
             _dialogService = dialogService;
             _trayProcessCommunicationService = trayProcessCommunicationService;
-            RestoreDefaultsCommand = new RelayCommand(async () => await RestoreDefaults().ConfigureAwait(false));
-            AddCommand = new RelayCommand<string>(async command => await Add(command).ConfigureAwait(false));
+            RestoreDefaultsCommand = new RelayCommand(async () => await RestoreDefaultsAsync().ConfigureAwait(false));
+            AddCommand = new RelayCommand<string>(async command => await AddAsync(command).ConfigureAwait(false));
 
             Initialize(_settingsService.GetCommandKeyBindings());
         }
@@ -33,10 +33,9 @@ namespace FluentTerminal.App.ViewModels.Settings
         public ObservableCollection<KeyBindingsViewModel> KeyBindings { get; } = new ObservableCollection<KeyBindingsViewModel>();
         public RelayCommand RestoreDefaultsCommand { get; }
 
-        private async Task Add(string command)
+        private Task AddAsync(string command)
         {
-            var keyBinding = KeyBindings.FirstOrDefault(k => k.Command == command);
-            await keyBinding?.ShowAddKeyBindingDialog();
+            return KeyBindings.First(k => k.Command == command).ShowAddKeyBindingDialogAsync();
         }
 
         private void ClearKeyBindings()
@@ -72,9 +71,10 @@ namespace FluentTerminal.App.ViewModels.Settings
             _trayProcessCommunicationService.UpdateToggleWindowKeyBindingsAsync();
         }
 
-        private async Task RestoreDefaults()
+        private async Task RestoreDefaultsAsync()
         {
-            var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"), I18N.Translate("ConfirmRestoreKeybindings"), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
+            var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
+                I18N.Translate("ConfirmRestoreKeybindings"), DialogButton.OK, DialogButton.Cancel);
 
             if (result == DialogButton.OK)
             {

--- a/FluentTerminal.App.ViewModels/Settings/KeyBindingsViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/KeyBindingsViewModel.cs
@@ -42,11 +42,11 @@ namespace FluentTerminal.App.ViewModels.Settings
 
         public ObservableCollection<KeyBindingViewModel> KeyBindings { get; } = new ObservableCollection<KeyBindingViewModel>();
 
-        public async Task ShowAddKeyBindingDialog()
+        public async Task ShowAddKeyBindingDialogAsync()
         {
             var newKeyBinding = new KeyBindingViewModel(new KeyBinding { Command = Command }, _dialogService, this);
 
-            if (await newKeyBinding.Edit().ConfigureAwait(true))
+            if (await newKeyBinding.EditAsync())
             {
                 Add(newKeyBinding.Model);
             }

--- a/FluentTerminal.App.ViewModels/Settings/KeyBindingsViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/KeyBindingsViewModel.cs
@@ -42,21 +42,25 @@ namespace FluentTerminal.App.ViewModels.Settings
 
         public ObservableCollection<KeyBindingViewModel> KeyBindings { get; } = new ObservableCollection<KeyBindingViewModel>();
 
+        // Requires UI thread
         public async Task ShowAddKeyBindingDialogAsync()
         {
             var newKeyBinding = new KeyBindingViewModel(new KeyBinding { Command = Command }, _dialogService, this);
 
-            if (await newKeyBinding.EditAsync())
+            // ConfigureAwait(true) because we need to execute Add method in the calling (UI) thread.
+            if (await newKeyBinding.EditAsync().ConfigureAwait(true))
             {
                 Add(newKeyBinding.Model);
             }
         }
 
+        // Requires UI thread
         public void Clear()
         {
             KeyBindings.Clear();
         }
 
+        // Requires UI thread
         public void Add(KeyBinding keyBinding)
         {
             var viewModel = new KeyBindingViewModel(keyBinding, _dialogService, this);

--- a/FluentTerminal.App.ViewModels/Settings/MousePageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/MousePageViewModel.cs
@@ -22,7 +22,7 @@ namespace FluentTerminal.App.ViewModels.Settings
             _defaultValueProvider = defaultValueProvider;
             _applicationSettings = _settingsService.GetApplicationSettings();
 
-            RestoreDefaultsCommand = new RelayCommand(async () => await RestoreDefaults().ConfigureAwait(false));
+            RestoreDefaultsCommand = new RelayCommand(async () => await RestoreDefaultsAsync().ConfigureAwait(false));
         }
 
         public bool CopyOnSelect
@@ -105,9 +105,10 @@ namespace FluentTerminal.App.ViewModels.Settings
 
         public RelayCommand RestoreDefaultsCommand { get; }
 
-        private async Task RestoreDefaults()
+        private async Task RestoreDefaultsAsync()
         {
-            var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"), I18N.Translate("ConfirmRestoreMouseSettings"), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
+            var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
+                I18N.Translate("ConfirmRestoreMouseSettings"), DialogButton.OK, DialogButton.Cancel);
 
             if (result == DialogButton.OK)
             {

--- a/FluentTerminal.App.ViewModels/Settings/MousePageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/MousePageViewModel.cs
@@ -105,10 +105,13 @@ namespace FluentTerminal.App.ViewModels.Settings
 
         public RelayCommand RestoreDefaultsCommand { get; }
 
+        // Requires UI thread
         private async Task RestoreDefaultsAsync()
         {
+            // ConfigureAwait(true) because we're setting some view-model properties afterwards.
             var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
-                I18N.Translate("ConfirmRestoreMouseSettings"), DialogButton.OK, DialogButton.Cancel);
+                    I18N.Translate("ConfirmRestoreMouseSettings"), DialogButton.OK, DialogButton.Cancel)
+                .ConfigureAwait(true);
 
             if (result == DialogButton.OK)
             {

--- a/FluentTerminal.App.ViewModels/Settings/SshProfilesPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/SshProfilesPageViewModel.cs
@@ -52,14 +52,14 @@ namespace FluentTerminal.App.ViewModels.Settings
 
         private void OnSshProfileDeleted(object sender, EventArgs e)
         {
-            if (sender is SshProfileViewModel shellProfile)
+            if (sender is SshProfileViewModel sshProfile)
             {
-                if (SelectedSshProfile == shellProfile)
+                if (SelectedSshProfile == sshProfile)
                 {
                     SelectedSshProfile = SshProfiles.First();
                 }
-                SshProfiles.Remove(shellProfile);
-                _settingsService.DeleteSshProfile(shellProfile.Id);
+                SshProfiles.Remove(sshProfile);
+                _settingsService.DeleteSshProfile(sshProfile.Id);
             }
         }
 

--- a/FluentTerminal.App.ViewModels/Settings/TerminalPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/TerminalPageViewModel.cs
@@ -226,10 +226,13 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
+        // Requires UI thread
         private async Task RestoreDefaultsAsync()
         {
+            // ConfigureAwait(true) because we're setting some view-model properties afterwards.
             var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
-                I18N.Translate("ConfirmRestoreTerminalOptions"), DialogButton.OK, DialogButton.Cancel);
+                    I18N.Translate("ConfirmRestoreTerminalOptions"), DialogButton.OK, DialogButton.Cancel)
+                .ConfigureAwait(true);
 
             if (result == DialogButton.OK)
             {

--- a/FluentTerminal.App.ViewModels/Settings/TerminalPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/TerminalPageViewModel.cs
@@ -226,9 +226,10 @@ namespace FluentTerminal.App.ViewModels.Settings
             }
         }
 
-        private async Task RestoreDefaults()
+        private async Task RestoreDefaultsAsync()
         {
-            var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"), I18N.Translate("ConfirmRestoreTerminalOptions"), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
+            var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
+                I18N.Translate("ConfirmRestoreTerminalOptions"), DialogButton.OK, DialogButton.Cancel);
 
             if (result == DialogButton.OK)
             {
@@ -252,7 +253,7 @@ namespace FluentTerminal.App.ViewModels.Settings
             _dialogService = dialogService;
             _defaultValueProvider = defaultValueProvider;
 
-            RestoreDefaultsCommand = new RelayCommand(async () => await RestoreDefaults().ConfigureAwait(false));
+            RestoreDefaultsCommand = new RelayCommand(async () => await RestoreDefaultsAsync().ConfigureAwait(false));
 
             Fonts = systemFontService.GetSystemFontFamilies().OrderBy(s => s.Name);
             Sizes = Enumerable.Range(2, 72);

--- a/FluentTerminal.App.ViewModels/Settings/ThemesPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/ThemesPageViewModel.cs
@@ -127,9 +127,13 @@ namespace FluentTerminal.App.ViewModels.Settings
             AddTheme(theme);
         }
 
+        // Requires UI thread
         private async Task ImportThemeAsync()
         {
-            var file = await _fileSystemService.OpenFileAsync(_themeParserFactory.SupportedFileTypes);
+            // ConfigureAwait(true) because we need to execute AddTheme method in the calling (UI) thread.
+            var file = await _fileSystemService.OpenFileAsync(_themeParserFactory.SupportedFileTypes)
+                .ConfigureAwait(true);
+
             if (file != null)
             {
                 var parser = _themeParserFactory.GetParser(file.FileType);
@@ -137,17 +141,23 @@ namespace FluentTerminal.App.ViewModels.Settings
                 if (parser == null)
                 {
                     await _dialogService.ShowMessageDialogAsync(I18N.Translate("ImportThemeFailed"),
-                        I18N.Translate("NoSuitableParserFound"), DialogButton.OK);
+                        I18N.Translate("NoSuitableParserFound"), DialogButton.OK).ConfigureAwait(false);
+
                     return;
                 }
 
                 try
                 {
+                    // ConfigureAwait(true) because we need to execute AddTheme method in the calling (UI) thread.
                     var exportedTheme = await parser.Import(file.Name, file.Content).ConfigureAwait(true);
 
                     if (!string.IsNullOrWhiteSpace(exportedTheme.EncodedImage))
                     {
-                        var importedImage = await _imageFileSystemService.ImportThemeImageAsync(exportedTheme.BackgroundImage, exportedTheme.EncodedImage);
+                        // ConfigureAwait(true) because we need to execute AddTheme method in the calling (UI) thread.
+                        var importedImage = await _imageFileSystemService
+                            .ImportThemeImageAsync(exportedTheme.BackgroundImage, exportedTheme.EncodedImage)
+                            .ConfigureAwait(true);
+
                         exportedTheme.BackgroundImage = importedImage;
                     }
 

--- a/FluentTerminal.App.ViewModels/Settings/ThemesPageViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Settings/ThemesPageViewModel.cs
@@ -42,7 +42,7 @@ namespace FluentTerminal.App.ViewModels.Settings
             _imageFileSystemService = imageFileSystemService;
 
             CreateThemeCommand = new RelayCommand(CreateTheme);
-            ImportThemeCommand = new AsyncCommand(ImportTheme);
+            ImportThemeCommand = new AsyncCommand(ImportThemeAsync);
             CloneCommand = new RelayCommand<ThemeViewModel>(CloneTheme);
 
             MessengerInstance.Register<TerminalOptionsChangedMessage>(this, OnTerminalOptionsChanged);
@@ -127,16 +127,17 @@ namespace FluentTerminal.App.ViewModels.Settings
             AddTheme(theme);
         }
 
-        private async Task ImportTheme()
+        private async Task ImportThemeAsync()
         {
-            var file = await _fileSystemService.OpenFile(_themeParserFactory.SupportedFileTypes).ConfigureAwait(true);
+            var file = await _fileSystemService.OpenFileAsync(_themeParserFactory.SupportedFileTypes);
             if (file != null)
             {
                 var parser = _themeParserFactory.GetParser(file.FileType);
 
                 if (parser == null)
                 {
-                    await _dialogService.ShowMessageDialogAsync(I18N.Translate("ImportThemeFailed"), I18N.Translate("NoSuitableParserFound"), DialogButton.OK).ConfigureAwait(false);
+                    await _dialogService.ShowMessageDialogAsync(I18N.Translate("ImportThemeFailed"),
+                        I18N.Translate("NoSuitableParserFound"), DialogButton.OK);
                     return;
                 }
 
@@ -156,7 +157,9 @@ namespace FluentTerminal.App.ViewModels.Settings
                 }
                 catch (Exception exception)
                 {
-                    await _dialogService.ShowMessageDialogAsync(I18N.Translate("ImportThemeFailed"), exception.Message, DialogButton.OK).ConfigureAwait(false);
+                    await _dialogService
+                        .ShowMessageDialogAsync(I18N.Translate("ImportThemeFailed"), exception.Message, DialogButton.OK)
+                        .ConfigureAwait(false);
                 }
             }
         }

--- a/FluentTerminal.App.ViewModels/ShellProfileViewModel.cs
+++ b/FluentTerminal.App.ViewModels/ShellProfileViewModel.cs
@@ -60,14 +60,14 @@ namespace FluentTerminal.App.ViewModels
                 shellProfile);
 
             SetDefaultCommand = new RelayCommand(SetDefault);
-            RestoreDefaultsCommand = new AsyncCommand(RestoreDefaults);
+            RestoreDefaultsCommand = new AsyncCommand(RestoreDefaultsAsync);
         }
 
         #endregion Constrcutor
 
         #region Methods
 
-        private async Task RestoreDefaults()
+        private async Task RestoreDefaultsAsync()
         {
             if (InEditMode || !ProfileVm.PreInstalled)
             {
@@ -75,7 +75,7 @@ namespace FluentTerminal.App.ViewModels
             }
 
             var result = await DialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
-                I18N.Translate("ConfirmRestoreProfile"), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
+                I18N.Translate("ConfirmRestoreProfile"), DialogButton.OK, DialogButton.Cancel);
 
             if (result == DialogButton.OK)
             {

--- a/FluentTerminal.App.ViewModels/ShellProfileViewModel.cs
+++ b/FluentTerminal.App.ViewModels/ShellProfileViewModel.cs
@@ -67,6 +67,7 @@ namespace FluentTerminal.App.ViewModels
 
         #region Methods
 
+        // Requires UI thread
         private async Task RestoreDefaultsAsync()
         {
             if (InEditMode || !ProfileVm.PreInstalled)
@@ -74,8 +75,9 @@ namespace FluentTerminal.App.ViewModels
                 throw new InvalidOperationException();
             }
 
+            // ConfigureAwait(true) because we need to execute Initialize method in the calling (UI) thread.
             var result = await DialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
-                I18N.Translate("ConfirmRestoreProfile"), DialogButton.OK, DialogButton.Cancel);
+                I18N.Translate("ConfirmRestoreProfile"), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
 
             if (result == DialogButton.OK)
             {

--- a/FluentTerminal.App.ViewModels/TerminalViewModel.cs
+++ b/FluentTerminal.App.ViewModels/TerminalViewModel.cs
@@ -40,7 +40,7 @@ namespace FluentTerminal.App.ViewModels
             public ShellProfile ShellProfile { get; set; }
         }
 
-        public async Task<string> Serialize()
+        public async Task<string> SerializeAsync()
         {
             TerminalState state = new TerminalState
             {
@@ -51,7 +51,7 @@ namespace FluentTerminal.App.ViewModels
                 TabTheme = TabTheme,
                 ShowSearchPanel = ShowSearchPanel,
                 SearchText = SearchText,
-                XtermBufferState = await SerializeXtermState(),
+                XtermBufferState = await SerializeXtermStateAsync(),
                 TerminalId = Terminal.Id,
                 ShellProfile = ShellProfile
             };
@@ -120,7 +120,7 @@ namespace FluentTerminal.App.ViewModels
             TabThemes = new ObservableCollection<TabTheme>(SettingsService.GetTabThemes());
             TabTheme = TabThemes.FirstOrDefault(t => t.Id == ShellProfile.TabThemeId);
 
-            CloseCommand = new AsyncCommand(CloseTab, CanExecuteCommand);
+            CloseCommand = new AsyncCommand(TryCloseAsync, CanExecuteCommand);
             CloseLeftTabsCommand = new RelayCommand(CloseLeftTabs, CanExecuteCommand);
             CloseRightTabsCommand = new RelayCommand(CloseRightTabs, CanExecuteCommand);
             CloseOtherTabsCommand = new RelayCommand(CloseOtherTabs, CanExecuteCommand);
@@ -128,7 +128,7 @@ namespace FluentTerminal.App.ViewModels
             FindPreviousCommand = new RelayCommand(FindPrevious, CanExecuteCommand);
             CloseSearchPanelCommand = new RelayCommand(CloseSearchPanel, CanExecuteCommand);
             SelectTabThemeCommand = new RelayCommand<string>(SelectTabTheme, CanExecuteCommand);
-            EditTitleCommand = new AsyncCommand(EditTitle, CanExecuteCommand);
+            EditTitleCommand = new AsyncCommand(EditTitleAsync, CanExecuteCommand);
             DuplicateTabCommand = new RelayCommand(DuplicateTab, CanExecuteCommand);
 
             if (!String.IsNullOrEmpty(terminalState))
@@ -350,11 +350,11 @@ namespace FluentTerminal.App.ViewModels
 
         public ITrayProcessCommunicationService TrayProcessCommunicationService { get; }
 
-        public Task Close()
+        public Task CloseAsync()
         {
             MessengerInstance.Unregister(this);
 
-            return Terminal.Close();
+            return Terminal.CloseAsync();
         }
 
         public void CopyText(string text)
@@ -366,7 +366,7 @@ namespace FluentTerminal.App.ViewModels
             }
         }
 
-        public async Task EditTitle()
+        public async Task EditTitleAsync()
         {
             var result = await DialogService.ShowInputDialogAsync(I18N.Translate("EditTitleString"));
             if (result != null)
@@ -406,11 +406,6 @@ namespace FluentTerminal.App.ViewModels
             return Initialized && !_disposalRequested;
         }
 
-        private async Task CloseTab()
-        {
-             await TryClose().ConfigureAwait(false);
-        }
-
         private void CloseLeftTabs()
         {
             CloseLeftTabsRequested?.Invoke(this, EventArgs.Empty);
@@ -433,9 +428,9 @@ namespace FluentTerminal.App.ViewModels
 
         public ITerminalView TerminalView { get; set; }
 
-        public Task<string> SerializeXtermState()
+        private Task<string> SerializeXtermStateAsync()
         {
-            return TerminalView?.SerializeXtermState() ?? Task.FromResult(string.Empty);
+            return TerminalView?.SerializeXtermStateAsync() ?? Task.FromResult(string.Empty);
         }
 
         private void FindPrevious()
@@ -512,29 +507,29 @@ namespace FluentTerminal.App.ViewModels
             {
                 case nameof(Command.Copy):
                     {
-                        var selection = await Terminal.GetSelectedText().ConfigureAwait(true);
+                        var selection = await Terminal.GetSelectedText().ConfigureAwait(false);
                         CopyText(selection);
-                        break;
+                        return;
                     }
                 case nameof(Command.Paste):
                     {
-                        string content = await ClipboardService.GetText().ConfigureAwait(true);
+                        string content = await ClipboardService.GetTextAsync().ConfigureAwait(false);
                         if (content != null)
                         {
                             content = ShellProfile.TranslateLineEndings(content);
                             await TerminalView.PasteAsync(content);
                         }
-                        break;
+                        return;
                     }
                 case nameof(Command.PasteWithoutNewlines):
                     {
-                        string content = await ClipboardService.GetText().ConfigureAwait(true);
+                        string content = await ClipboardService.GetTextAsync().ConfigureAwait(false);
                         if (content != null)
                         {
                             content = ShellProfile.NewlinePattern.Replace(content, string.Empty);
                             await TerminalView.PasteAsync(content);
                         }
-                        break;
+                        return;
                     }
                 case nameof(Command.Search):
                     {
@@ -545,13 +540,14 @@ namespace FluentTerminal.App.ViewModels
                             {
                                 SearchStarted?.Invoke(this, EventArgs.Empty);
                             }
-                        });
-                        break;
+                        }).ConfigureAwait(false);
+                        return;
                     }
                 default:
                     {
-                        await ApplicationView.ExecuteOnUiThreadAsync(() => _keyboardCommandService.SendCommand(e));
-                        break;
+                        await ApplicationView.ExecuteOnUiThreadAsync(() => _keyboardCommandService.SendCommand(e))
+                            .ConfigureAwait(false);
+                        return;
                     }
             }
         }
@@ -579,7 +575,7 @@ namespace FluentTerminal.App.ViewModels
             ApplicationView.ExecuteOnUiThreadAsync(() => ShellTitle = e);
         }
 
-        private async Task TryClose()
+        private async Task TryCloseAsync()
         {
             if (ShellProfile?.Tag is ISessionSuccessTracker tracker)
             {
@@ -588,7 +584,10 @@ namespace FluentTerminal.App.ViewModels
 
             if (ApplicationSettings.ConfirmClosingTabs)
             {
-                var result = await DialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"), String.Format(I18N.Translate("ConfirmCloseTab"), ShellTitle), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
+                var result = await DialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
+                        string.Format(I18N.Translate("ConfirmCloseTab"), ShellTitle), DialogButton.OK,
+                        DialogButton.Cancel)
+                    .ConfigureAwait(false);
 
                 if (result == DialogButton.Cancel)
                 {
@@ -596,7 +595,7 @@ namespace FluentTerminal.App.ViewModels
                 }
             }
 
-            await Close().ConfigureAwait(true);
+            await CloseAsync().ConfigureAwait(false);
         }
     }
 }

--- a/FluentTerminal.App.ViewModels/ThemeViewModel.cs
+++ b/FluentTerminal.App.ViewModels/ThemeViewModel.cs
@@ -294,6 +294,7 @@ namespace FluentTerminal.App.ViewModels
 
         public RelayCommand DeleteBackgroundImageCommand { get; }
 
+        // Requires UI thread
         private async Task SaveChangesAsync()
         {
             Model.Name = Name;
@@ -326,11 +327,14 @@ namespace FluentTerminal.App.ViewModels
             if (Model.BackgroundImage != null &&
                BackgroundThemeFile != Model?.BackgroundImage)
             {
-                await _imageFileSystemService.RemoveImportedImageAsync(
-                    $"{Model.BackgroundImage?.Name}{Model.BackgroundImage?.FileType}");
+                // ConfigureAwait(true) because we're setting some view-model properties afterwards.
+                await _imageFileSystemService
+                    .RemoveImportedImageAsync($"{Model.BackgroundImage?.Name}{Model.BackgroundImage?.FileType}")
+                    .ConfigureAwait(true);
             }
 
-            BackgroundThemeFile = await SaveBackgroundImageAsync();
+            // ConfigureAwait(true) because we're setting some view-model properties afterwards.
+            BackgroundThemeFile = await SaveBackgroundImageAsync().ConfigureAwait(true);
 
             Model.BackgroundImage = BackgroundThemeFile;
 
@@ -340,91 +344,94 @@ namespace FluentTerminal.App.ViewModels
             _isNew = false;
         }
 
+        // Requires UI thread
         private async Task CancelEditAsync()
         {
             if (_isNew)
             {
-                await DeleteAsync();
+                await DeleteAsync().ConfigureAwait(false);
+
+                return;
+            }
+
+            TerminalTheme changedTheme = new TerminalTheme()
+            {
+                Name = Name,
+                Author = Author,
+                BackgroundImage = BackgroundThemeFile,
+                Colors = new TerminalColors()
+                {
+                    Black = Black,
+                    Red = Red,
+                    Green = Green,
+                    Yellow = Yellow,
+                    Blue = Blue,
+                    Magenta = Magenta,
+                    Cyan = Cyan,
+                    White = White,
+
+                    BrightBlack = BrightBlack,
+                    BrightRed = BrightRed,
+                    BrightGreen = BrightGreen,
+                    BrightYellow = BrightYellow,
+                    BrightBlue = BrightBlue,
+                    BrightMagenta = BrightMagenta,
+                    BrightCyan = BrightCyan,
+                    BrightWhite = BrightWhite,
+
+                    Background = Background,
+                    Foreground = Foreground,
+                    Cursor = Cursor,
+                    CursorAccent = CursorAccent,
+                    Selection = Selection
+                }
+            };
+
+            if (!_fallbackTheme.Equals(changedTheme))
+            {
+                // ConfigureAwait(true) because we're setting some view-model properties afterwards.
+                var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
+                    I18N.Translate("ConfirmDiscardChanges"), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
+
+                if (result == DialogButton.OK)
+                {
+                    Black = _fallbackTheme.Colors.Black;
+                    Red = _fallbackTheme.Colors.Red;
+                    Green = _fallbackTheme.Colors.Green;
+                    Yellow = _fallbackTheme.Colors.Yellow;
+                    Blue = _fallbackTheme.Colors.Blue;
+                    Magenta = _fallbackTheme.Colors.Magenta;
+                    Cyan = _fallbackTheme.Colors.Cyan;
+                    White = _fallbackTheme.Colors.White;
+
+                    BrightBlack = _fallbackTheme.Colors.BrightBlack;
+                    BrightRed = _fallbackTheme.Colors.BrightRed;
+                    BrightGreen = _fallbackTheme.Colors.BrightGreen;
+                    BrightYellow = _fallbackTheme.Colors.BrightYellow;
+                    BrightBlue = _fallbackTheme.Colors.BrightBlue;
+                    BrightMagenta = _fallbackTheme.Colors.BrightMagenta;
+                    BrightCyan = _fallbackTheme.Colors.BrightCyan;
+                    BrightWhite = _fallbackTheme.Colors.BrightWhite;
+
+                    Background = _fallbackTheme.Colors.Background;
+                    Foreground = _fallbackTheme.Colors.Foreground;
+                    Cursor = _fallbackTheme.Colors.Cursor;
+                    CursorAccent = _fallbackTheme.Colors.CursorAccent;
+                    Selection = _fallbackTheme.Colors.Selection;
+
+                    Name = _fallbackTheme.Name;
+                    Author = _fallbackTheme.Author;
+
+                    BackgroundThemeFile = _fallbackTheme.BackgroundImage;
+
+                    InEditMode = false;
+
+                    await _imageFileSystemService.RemoveTemporaryBackgroundThemeImageAsync().ConfigureAwait(false);
+                }
             }
             else
             {
-                TerminalTheme changedTheme = new TerminalTheme()
-                {
-                    Name = Name,
-                    Author = Author,
-                    BackgroundImage = BackgroundThemeFile,
-                    Colors = new TerminalColors()
-                    {
-                        Black = Black,
-                        Red = Red,
-                        Green = Green,
-                        Yellow = Yellow,
-                        Blue = Blue,
-                        Magenta = Magenta,
-                        Cyan = Cyan,
-                        White = White,
-
-                        BrightBlack = BrightBlack,
-                        BrightRed = BrightRed,
-                        BrightGreen = BrightGreen,
-                        BrightYellow = BrightYellow,
-                        BrightBlue = BrightBlue,
-                        BrightMagenta = BrightMagenta,
-                        BrightCyan = BrightCyan,
-                        BrightWhite = BrightWhite,
-
-                        Background = Background,
-                        Foreground = Foreground,
-                        Cursor = Cursor,
-                        CursorAccent = CursorAccent,
-                        Selection = Selection
-                    }
-                };
-
-                if (!_fallbackTheme.Equals(changedTheme))
-                {
-                    var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"), I18N.Translate("ConfirmDiscardChanges"), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
-
-                    if (result == DialogButton.OK)
-                    {
-                        Black = _fallbackTheme.Colors.Black;
-                        Red = _fallbackTheme.Colors.Red;
-                        Green = _fallbackTheme.Colors.Green;
-                        Yellow = _fallbackTheme.Colors.Yellow;
-                        Blue = _fallbackTheme.Colors.Blue;
-                        Magenta = _fallbackTheme.Colors.Magenta;
-                        Cyan = _fallbackTheme.Colors.Cyan;
-                        White = _fallbackTheme.Colors.White;
-
-                        BrightBlack = _fallbackTheme.Colors.BrightBlack;
-                        BrightRed = _fallbackTheme.Colors.BrightRed;
-                        BrightGreen = _fallbackTheme.Colors.BrightGreen;
-                        BrightYellow = _fallbackTheme.Colors.BrightYellow;
-                        BrightBlue = _fallbackTheme.Colors.BrightBlue;
-                        BrightMagenta = _fallbackTheme.Colors.BrightMagenta;
-                        BrightCyan = _fallbackTheme.Colors.BrightCyan;
-                        BrightWhite = _fallbackTheme.Colors.BrightWhite;
-
-                        Background = _fallbackTheme.Colors.Background;
-                        Foreground = _fallbackTheme.Colors.Foreground;
-                        Cursor = _fallbackTheme.Colors.Cursor;
-                        CursorAccent = _fallbackTheme.Colors.CursorAccent;
-                        Selection = _fallbackTheme.Colors.Selection;
-
-                        Name = _fallbackTheme.Name;
-                        Author = _fallbackTheme.Author;
-
-                        BackgroundThemeFile = _fallbackTheme.BackgroundImage;
-
-                        InEditMode = false;
-
-                        await _imageFileSystemService.RemoveTemporaryBackgroundThemeImageAsync();
-                    }
-                }
-                else
-                {
-                    InEditMode = false;
-                }
+                InEditMode = false;
             }
         }
 
@@ -433,24 +440,31 @@ namespace FluentTerminal.App.ViewModels
             return !Model.PreInstalled;
         }
 
+        // Requires UI thread
         private async Task DeleteAsync()
         {
+            // ConfigureAwait(true) because we need to trigger Deleted event in the calling (UI) thread.
             var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
-                I18N.Translate("ConfirmDeleteTheme"), DialogButton.OK, DialogButton.Cancel);
+                I18N.Translate("ConfirmDeleteTheme"), DialogButton.OK, DialogButton.Cancel).ConfigureAwait(true);
 
             if (result == DialogButton.OK)
             {
-                await DeleteBackgroundImageIfExistsAsync();
-                await _imageFileSystemService.RemoveTemporaryBackgroundThemeImageAsync();
+                // ConfigureAwait(true) because we need to trigger Deleted event in the calling (UI) thread.
+                await DeleteBackgroundImageIfExistsAsync().ConfigureAwait(true);
+                // ConfigureAwait(true) because we need to trigger Deleted event in the calling (UI) thread.
+                await _imageFileSystemService.RemoveTemporaryBackgroundThemeImageAsync().ConfigureAwait(true);
 
                 Deleted?.Invoke(this, EventArgs.Empty);
             }
         }
 
+        // Requires UI thread
         private async Task DeleteBackgroundImageAsync()
         {
+            // ConfigureAwait(true) because we're setting some view-model properties afterwards.
             var result = await _dialogService.ShowMessageDialogAsync(I18N.Translate("PleaseConfirm"),
-                I18N.Translate("ConfirmDeleteBackgroundImage"), DialogButton.OK, DialogButton.Cancel);
+                    I18N.Translate("ConfirmDeleteBackgroundImage"), DialogButton.OK, DialogButton.Cancel)
+                .ConfigureAwait(true);
 
             if (result == DialogButton.OK)
             {
@@ -497,26 +511,33 @@ namespace FluentTerminal.App.ViewModels
             return importedBackgroundThemeFile;
         }
 
+        // Requires UI thread
         private async Task ChooseBackgroundImageAsync()
         {
-            var chosenImage = await _imageFileSystemService.ImportTemporaryImageFileAsync(new[] { ".jpeg", ".png", ".jpg" });
+            // ConfigureAwait(true) because we're setting some view-model properties afterwards.
+            var chosenImage = await _imageFileSystemService
+                .ImportTemporaryImageFileAsync(new[] {".jpeg", ".png", ".jpg"}).ConfigureAwait(true);
 
-            if(chosenImage == null)
+            if(chosenImage != null)
             {
-                return;
+                BackgroundThemeFile = chosenImage;
             }
-
-            BackgroundThemeFile = chosenImage;
         }
 
+        // Requires UI thread
         private async Task DeleteBackgroundImageIfExistsAsync()
         {
             if (BackgroundThemeFile != null)
             {
-                await _imageFileSystemService.RemoveImportedImageAsync(
-                    $"{Model.BackgroundImage?.Name}{Model.BackgroundImage?.FileType}");
+                var imageFile = Model.BackgroundImage;
 
                 BackgroundThemeFile = null;
+
+                if (imageFile != null)
+                {
+                    await _imageFileSystemService.RemoveImportedImageAsync($"{imageFile.Name}{imageFile.FileType}")
+                        .ConfigureAwait(false);
+                }
             }
         }
     }

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -608,7 +608,7 @@ namespace FluentTerminal.App
                 Window.Current.Activate();
 
                 windowId = ApplicationView.GetForCurrentView().Id;
-            });
+            }).ConfigureAwait(false);
 
             if (viewModel is SettingsViewModel settingsViewModel)
             {
@@ -677,9 +677,9 @@ namespace FluentTerminal.App
 
         private async void OnNewWindowRequested(object sender, NewWindowRequestedEventArgs e)
         {
-            var viewModel = await CreateNewTerminalWindowAsync();
+            var viewModel = await CreateNewTerminalWindowAsync().ConfigureAwait(false);
 
-            await viewModel.AddTabAsync(e.Profile);
+            await viewModel.AddTabAsync(e.Profile).ConfigureAwait(false);
         }
 
         private void OnSettingsClosed(object sender, EventArgs e)

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -672,7 +672,7 @@ namespace FluentTerminal.App
             Logger.Instance.Debug("App.xaml.cs on tab tear off");
 
             var newViewModel = await CreateNewTerminalWindowAsync();
-            await newViewModel.AddTabAsync(await model.Serialize(), 0);
+            await newViewModel.AddTabAsync(await model.SerializeAsync(), 0);
         }
 
         private async void OnNewWindowRequested(object sender, NewWindowRequestedEventArgs e)

--- a/FluentTerminal.App/Services/ClipboardService.cs
+++ b/FluentTerminal.App/Services/ClipboardService.cs
@@ -19,7 +19,7 @@ namespace FluentTerminal.App.Services
             _settingsService = settingsService;
         }
 
-        public Task<string> GetText()
+        public Task<string> GetTextAsync()
         {
             var content = Clipboard.GetContent();
             if (content.Contains(StandardDataFormats.Text))

--- a/FluentTerminal.App/Services/FileSystemService.cs
+++ b/FluentTerminal.App/Services/FileSystemService.cs
@@ -11,7 +11,7 @@ namespace FluentTerminal.App.Services
 {
     public class FileSystemService : IFileSystemService
     {
-        public Task<string> BrowseForDirectory()
+        public Task<string> BrowseForDirectoryAsync()
         {
             var picker = new FolderPicker{ SuggestedStartLocation = PickerLocationId.ComputerFolder };
             picker.FileTypeFilter.Add(".whatever"); // else a ComException is thrown
@@ -20,7 +20,7 @@ namespace FluentTerminal.App.Services
                 .ContinueWith(t => t.Result?.Path, TaskContinuationOptions.OnlyOnRanToCompletion);
         }
 
-        public async Task<File> OpenFile(IEnumerable<string> fileTypes)
+        public async Task<File> OpenFileAsync(IEnumerable<string> fileTypes)
         {
             var picker = new FileOpenPicker
             {
@@ -42,7 +42,7 @@ namespace FluentTerminal.App.Services
             return null;
         }
 
-        public async Task<ImageFile> SaveImageInRoaming(ImageFile imageFile)
+        public async Task<ImageFile> SaveImageInRoamingAsync(ImageFile imageFile)
         {
             var file = await StorageFile.GetFileFromPathAsync(imageFile.Path);
 
@@ -56,7 +56,7 @@ namespace FluentTerminal.App.Services
                 storageFile.Path);
         }
 
-        public async Task SaveTextFile(string name, string fileTypeDescription, string fileType, string content)
+        public async Task SaveTextFileAsync(string name, string fileTypeDescription, string fileType, string content)
         {
             var picker = new FileSavePicker
             {

--- a/FluentTerminal.App/Services/StartupTaskService.cs
+++ b/FluentTerminal.App/Services/StartupTaskService.cs
@@ -9,20 +9,20 @@ namespace FluentTerminal.App.Services
     {
         private const string StartupTaskName = "FluentTerminalStartupTask";
 
-        public Task<StartupTaskStatus> GetStatus()
+        public Task<StartupTaskStatus> GetStatusAsync()
         {
             return StartupTask.GetAsync(StartupTaskName).AsTask().ContinueWith(t => ToStartupTaskStatus(t.Result.State),
                 TaskContinuationOptions.OnlyOnRanToCompletion);
         }
 
-        public async Task<StartupTaskStatus> EnableStartupTask()
+        public async Task<StartupTaskStatus> EnableStartupTaskAsync()
         {
             var startupTask = await StartupTask.GetAsync(StartupTaskName);
             var newState = await startupTask.RequestEnableAsync();
             return ToStartupTaskStatus(newState);
         }
 
-        public Task DisableStartupTask()
+        public Task DisableStartupTaskAsync()
         {
             return StartupTask.GetAsync(StartupTaskName).AsTask().ContinueWith(t => t.Result.Disable(),
                 TaskContinuationOptions.OnlyOnRanToCompletion);

--- a/FluentTerminal.App/Views/TabBar.xaml.cs
+++ b/FluentTerminal.App/Views/TabBar.xaml.cs
@@ -166,7 +166,7 @@ namespace FluentTerminal.App.Views
             if (item is TerminalViewModel model)
             {
                 await model.TrayProcessCommunicationService.PauseTerminalOutputAsync(model.Terminal.Id, true);
-                e.Data.Properties.Add(Constants.TerminalViewModelStateId, await model.Serialize());
+                e.Data.Properties.Add(Constants.TerminalViewModelStateId, await model.SerializeAsync());
             }
         }
 

--- a/FluentTerminal.App/Views/TerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/TerminalView.xaml.cs
@@ -31,7 +31,7 @@ namespace FluentTerminal.App.Views
             InitializeComponent();
             _terminalView = new XtermTerminalView();
             TerminalContainer.Children.Add((UIElement)_terminalView);
-            _terminalView.Initialize(ViewModel);
+            _terminalView.InitializeAsync(ViewModel);
             ViewModel.TerminalView = _terminalView;
             ViewModel.Initialized = true;
 
@@ -62,27 +62,27 @@ namespace FluentTerminal.App.Views
 
         private void OnActivated(object sender, EventArgs e)
         {
-            _terminalView?.FocusTerminal();
+            _terminalView?.FocusTerminalAsync();
         }
 
         private void OnFindNextRequested(object sender, string e)
         {
-            _terminalView.FindNext(e);
+            _terminalView.FindNextAsync(e);
         }
 
         private void OnFindPreviousRequested(object sender, string e)
         {
-            _terminalView.FindPrevious(e);
+            _terminalView.FindPreviousAsync(e);
         }
 
         private void OnKeyBindingsChanged(KeyBindingsChangedMessage message)
         {
-            _terminalView.ChangeKeyBindings();
+            _terminalView.ChangeKeyBindingsAsync();
         }
 
         private void OnTerminalOptionsChanged(TerminalOptionsChangedMessage message)
         {
-            _terminalView.ChangeOptions(message.TerminalOptions);
+            _terminalView.ChangeOptionsAsync(message.TerminalOptions);
         }
 
         private void OnSearchStarted(object sender, EventArgs e)
@@ -104,7 +104,7 @@ namespace FluentTerminal.App.Views
 
         private async void OnThemeChanged(object sender, TerminalTheme e)
         {
-            await _terminalView.ChangeTheme(e);
+            await _terminalView.ChangeThemeAsync(e);
             SetGridBackgroundTheme(e);
         }
                

--- a/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/XtermTerminalView.xaml.cs
@@ -157,7 +157,7 @@ namespace FluentTerminal.App.Views
 
         public TerminalViewModel ViewModel { get; private set; }
 
-        public Task ChangeKeyBindings()
+        public Task ChangeKeyBindingsAsync()
         {
             if (_terminalClosed)
             {
@@ -171,7 +171,7 @@ namespace FluentTerminal.App.Views
             return ExecuteScriptAsync($"changeKeyBindings('{serialized}')");
         }
 
-        public Task ChangeOptions(TerminalOptions options)
+        public Task ChangeOptionsAsync(TerminalOptions options)
         {
             if (_terminalClosed)
             {
@@ -181,7 +181,7 @@ namespace FluentTerminal.App.Views
             return _optionsChanged.InvokeAsync(options);
         }
 
-        public Task ChangeTheme(TerminalTheme theme)
+        public Task ChangeThemeAsync(TerminalTheme theme)
         {
             if (_terminalClosed)
             {
@@ -192,7 +192,7 @@ namespace FluentTerminal.App.Views
             return ExecuteScriptAsync($"changeTheme('{serialized}')");
         }
 
-        public Task<string> SerializeXtermState()
+        public Task<string> SerializeXtermStateAsync()
         {
             if (_terminalClosed)
             {
@@ -202,7 +202,7 @@ namespace FluentTerminal.App.Views
             return ExecuteScriptAsync(@"serializeTerminal()");
         }
 
-        public Task FindNext(string searchText)
+        public Task FindNextAsync(string searchText)
         {
             if (_terminalClosed)
             {
@@ -212,7 +212,7 @@ namespace FluentTerminal.App.Views
             return ExecuteScriptAsync($"findNext('{searchText}')");
         }
 
-        public Task FindPrevious(string searchText)
+        public Task FindPreviousAsync(string searchText)
         {
             if (_terminalClosed)
             {
@@ -222,7 +222,7 @@ namespace FluentTerminal.App.Views
             return ExecuteScriptAsync($"findPrevious('{searchText}')");
         }
 
-        public Task FocusTerminal()
+        public Task FocusTerminalAsync()
         {
             if (_terminalClosed)
             {
@@ -238,7 +238,7 @@ namespace FluentTerminal.App.Views
             return Task.CompletedTask;
         }
         
-        public async Task Initialize(TerminalViewModel viewModel)
+        public async Task InitializeAsync(TerminalViewModel viewModel)
         {
             ViewModel = viewModel;
             ViewModel.Terminal.OutputReceived += Terminal_OutputReceived;

--- a/FluentTerminal.SystemTray/Program.cs
+++ b/FluentTerminal.SystemTray/Program.cs
@@ -81,7 +81,7 @@ namespace FluentTerminal.SystemTray
 
 #if !STORE
                     // ReSharper disable once AssignmentIsFullyDiscarded
-                    _ = Task.Factory.StartNew(() => container.Resolve<IUpdateService>().CheckForUpdate());
+                    _ = Task.Factory.StartNew(() => container.Resolve<IUpdateService>().CheckForUpdateAsync());
 #endif
                     var settingsService = container.Resolve<ISettingsService>();
 


### PR DESCRIPTION
Part of https://github.com/jumptrading/FluentTerminal/issues/237

The key changes:
- `ConfigureAwait(false)` used wherever applicable;
- `Async` suffix added to async methods (i.e. `Delete` renamed to `DeleteAsync`).
- Some other minor cosmetic changes here and there, like changing `public` method to `private`, adding some comments, etc.

This PR doesn't introduce any functional change.