### PR TITLE
"Use buffer" option, only for ConPTY

### DIFF
--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -415,6 +415,7 @@ namespace FluentTerminal.App.Services.Implementation
                     PreInstalled = true,
                     WorkingDirectory = string.Empty,
                     UseConPty = ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 8), // Windows 10 1903+
+                    UseBuffer = false,
                     EnvironmentVariables = new Dictionary<string, string>
                     {
                         ["TERM"] = "xterm-256color"
@@ -442,6 +443,7 @@ namespace FluentTerminal.App.Services.Implementation
                     PreInstalled = true,
                     WorkingDirectory = string.Empty,
                     UseConPty = ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7), // Windows 10 1809+
+                    UseBuffer = true,
                     EnvironmentVariables = new Dictionary<string, string>
                     {
                         ["TERM"] = "xterm-256color"
@@ -469,6 +471,7 @@ namespace FluentTerminal.App.Services.Implementation
                     PreInstalled = true,
                     WorkingDirectory = string.Empty,
                     UseConPty = ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 7), // Windows 10 1809+
+                    UseBuffer = true, //TODO: Set to false if the buffer causes issues with WSL.
                     EnvironmentVariables = new Dictionary<string, string>
                     {
                         ["TERM"] = "xterm-256color"

--- a/FluentTerminal.App.ViewModels/Profiles/ProfileProviderViewModelBase.cs
+++ b/FluentTerminal.App.ViewModels/Profiles/ProfileProviderViewModelBase.cs
@@ -151,15 +151,22 @@ namespace FluentTerminal.App.ViewModels.Profiles
         public bool UseConPty
         {
             get => _useConPty;
-            set => Set(ref _useConPty, value);
+            set
+            {
+                if (Set(ref _useConPty, value)) RaisePropertyChanged(nameof(UseBuffer));
+            }
         }
 
         private bool _useBuffer;
 
+        // If UseConPty is false, getter will return true no matter the actual value set, and any attempt to set the value will be ignored.
         public bool UseBuffer
         {
-            get => _useBuffer;
-            set => Set(ref _useBuffer, value);
+            get => !_useConPty || _useBuffer;
+            set
+            {
+                if (_useConPty) Set(ref _useBuffer, value);
+            }
         }
 
         #endregion Properties
@@ -236,7 +243,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
         protected virtual Task CopyToProfileAsync(ShellProfile profile)
         {
             profile.UseConPty = _useConPty;
-            profile.UseBuffer = _useBuffer;
+            profile.UseBuffer = UseBuffer;
             profile.TerminalThemeId = _terminalThemeId;
             profile.TabThemeId = _tabThemeId;
             return Task.CompletedTask;
@@ -254,7 +261,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
         public virtual bool HasChanges()
         {
             return Model.UseConPty != _useConPty ||
-                   Model.UseBuffer != _useBuffer ||
+                   Model.UseBuffer != UseBuffer ||
                    !Model.TerminalThemeId.Equals(_terminalThemeId) ||
                    Model.TabThemeId != _tabThemeId;
         }
@@ -330,7 +337,7 @@ URL={0}
 
         public string GetBaseQueryString()
         {
-            var queryString = $"{UseConPtyQueryStringName}={_useConPty}&{UseBufferQueryStringName}={_useBuffer}";
+            var queryString = $"{UseConPtyQueryStringName}={_useConPty}&{UseBufferQueryStringName}={UseBuffer}";
 
             if (_tabThemeId != TabThemes.First().Id)
             {

--- a/FluentTerminal.App.ViewModels/Profiles/ProfileProviderViewModelBase.cs
+++ b/FluentTerminal.App.ViewModels/Profiles/ProfileProviderViewModelBase.cs
@@ -154,6 +154,14 @@ namespace FluentTerminal.App.ViewModels.Profiles
             set => Set(ref _useConPty, value);
         }
 
+        private bool _useBuffer;
+
+        public bool UseBuffer
+        {
+            get => _useBuffer;
+            set => Set(ref _useBuffer, value);
+        }
+
         #endregion Properties
 
         #region Constructor
@@ -215,6 +223,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
         private void Initialize(ShellProfile profile)
         {
             UseConPty = profile.UseConPty;
+            UseBuffer = profile.UseBuffer;
             TerminalThemeId = profile.TerminalThemeId;
             TabThemeId = profile.TabThemeId;
         }
@@ -227,6 +236,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
         protected virtual Task CopyToProfileAsync(ShellProfile profile)
         {
             profile.UseConPty = _useConPty;
+            profile.UseBuffer = _useBuffer;
             profile.TerminalThemeId = _terminalThemeId;
             profile.TabThemeId = _tabThemeId;
             return Task.CompletedTask;
@@ -244,6 +254,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
         public virtual bool HasChanges()
         {
             return Model.UseConPty != _useConPty ||
+                   Model.UseBuffer != _useBuffer ||
                    !Model.TerminalThemeId.Equals(_terminalThemeId) ||
                    Model.TabThemeId != _tabThemeId;
         }
@@ -279,6 +290,7 @@ namespace FluentTerminal.App.ViewModels.Profiles
         #region Links/shortcuts related
 
         private const string UseConPtyQueryStringName = "conpty";
+        private const string UseBufferQueryStringName = "buffer";
         private const string TerminalThemeIdQueryStringName = "theme";
         private const string TabThemeIdQueryStringName = "tab";
 
@@ -318,8 +330,7 @@ URL={0}
 
         public string GetBaseQueryString()
         {
-            var queryString =
-                $"{UseConPtyQueryStringName}={_useConPty}";
+            var queryString = $"{UseConPtyQueryStringName}={_useConPty}&{UseBufferQueryStringName}={_useBuffer}";
 
             if (_tabThemeId != TabThemes.First().Id)
             {
@@ -347,6 +358,14 @@ URL={0}
             if (!string.IsNullOrEmpty(keyValue?.Item2) && bool.TryParse(keyValue.Item2?.ToLower(), out bool useConPty))
             {
                 UseConPty = useConPty;
+            }
+
+            keyValue = queryStringParams.FirstOrDefault(t =>
+                UseBufferQueryStringName.Equals(t.Item1, StringComparison.OrdinalIgnoreCase));
+
+            if (!string.IsNullOrEmpty(keyValue?.Item2) && bool.TryParse(keyValue.Item2?.ToLower(), out bool useBuffer))
+            {
+                UseConPty = useBuffer;
             }
 
             keyValue = queryStringParams.FirstOrDefault(t =>

--- a/FluentTerminal.App/App.xaml.cs
+++ b/FluentTerminal.App/App.xaml.cs
@@ -424,6 +424,11 @@ namespace FluentTerminal.App
                     WorkingDirectory = runVerb.Directory
                 };
 
+                if (!string.IsNullOrEmpty(runVerb.Buffer) && bool.TryParse(runVerb.Buffer, out var useBuffer))
+                {
+                    profile.UseBuffer = useBuffer;
+                }
+
                 if (!string.IsNullOrWhiteSpace(runVerb.Theme))
                 {
                     var theme = _settingsService.GetThemes().FirstOrDefault(x => x.Name.Equals(runVerb.Theme, StringComparison.CurrentCultureIgnoreCase));

--- a/FluentTerminal.App/CommandLineArguments/RunVerb.cs
+++ b/FluentTerminal.App/CommandLineArguments/RunVerb.cs
@@ -14,6 +14,9 @@ namespace FluentTerminal.App.CommandLineArguments
         [Option("theme")]
         public string Theme { get; set; }
 
+        [Option("buffer")]
+        public string Buffer { get; set; }
+
         [Option("target")]
         public Target Target { get; set; }
     }

--- a/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml
+++ b/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml
@@ -79,6 +79,7 @@
                     <RowDefinition />
                     <RowDefinition />
                     <RowDefinition />
+                    <RowDefinition />
                 </Grid.RowDefinitions>
 
                 <!--  Row  -->
@@ -123,6 +124,15 @@
                     Margin="0,8,0,0"
                     Content="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=UseConPty}"
                     IsChecked="{x:Bind ViewModel.UseConPty, Mode=TwoWay}" />
+
+                <!--  Row  -->
+                <CheckBox
+                    Grid.Row="3"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="2"
+                    Margin="0,8,0,0"
+                    Content="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=UseBuffer}"
+                    IsChecked="{x:Bind ViewModel.UseBuffer, Mode=TwoWay}" />
 
             </Grid>
         </controls:Expander>

--- a/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml
+++ b/FluentTerminal.App/Dialogs/CustomCommandDialog.xaml
@@ -127,6 +127,7 @@
 
                 <!--  Row  -->
                 <CheckBox
+                    IsEnabled="{x:Bind ViewModel.UseConPty, Mode=OneWay}"
                     Grid.Row="3"
                     Grid.Column="0"
                     Grid.ColumnSpan="2"

--- a/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
+++ b/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
@@ -212,6 +212,7 @@
 
                     <!--  Row  -->
                     <CheckBox
+                        IsEnabled="{x:Bind ViewModel.UseConPty, Mode=OneWay}"
                         Grid.Row="4"
                         Grid.Column="0"
                         Grid.ColumnSpan="4"

--- a/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
+++ b/FluentTerminal.App/Dialogs/SshInfoDialog.xaml
@@ -129,6 +129,7 @@
                         <RowDefinition />
                         <RowDefinition />
                         <RowDefinition />
+                        <RowDefinition />
                     </Grid.RowDefinitions>
 
                     <!--  Row  -->
@@ -208,6 +209,15 @@
                         Margin="0,8,0,0"
                         Content="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=UseConPty}"
                         IsChecked="{x:Bind ViewModel.UseConPty, Mode=TwoWay}" />
+
+                    <!--  Row  -->
+                    <CheckBox
+                        Grid.Row="4"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="4"
+                        Margin="0,8,0,0"
+                        Content="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=UseBuffer}"
+                        IsChecked="{x:Bind ViewModel.UseBuffer, Mode=TwoWay}" />
 
                 </Grid>
             </controls:Expander>

--- a/FluentTerminal.App/Strings/en/Resources.resw
+++ b/FluentTerminal.App/Strings/en/Resources.resw
@@ -1108,4 +1108,7 @@ Fuzzy</comment>
   <data name="MouseCopySelectionOrPaste.Content" xml:space="preserve">
     <value>Copy selection or paste</value>
   </data>
+  <data name="UseBuffer" xml:space="preserve">
+    <value>Use buffer</value>
+  </data>
 </root>

--- a/FluentTerminal.App/Views/SettingsPages/ShellProfileSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/ShellProfileSettings.xaml
@@ -250,6 +250,7 @@
                                     IsOn="{x:Bind ProfileVm.UseConPty, Mode=TwoWay}" />
 
                                 <ToggleSwitch
+                                    Visibility="{x:Bind ProfileVm.UseConPty, Converter={StaticResource TrueToVisibleConverter}, Mode=OneWay}"
                                     x:Uid="UseBuffer"
                                     Margin="{StaticResource ItemMargin}"
                                     Header="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=UseBuffer}"

--- a/FluentTerminal.App/Views/SettingsPages/ShellProfileSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/ShellProfileSettings.xaml
@@ -249,6 +249,13 @@
                                     IsEnabled="{x:Bind InEditMode, Mode=OneWay}"
                                     IsOn="{x:Bind ProfileVm.UseConPty, Mode=TwoWay}" />
 
+                                <ToggleSwitch
+                                    x:Uid="UseBuffer"
+                                    Margin="{StaticResource ItemMargin}"
+                                    Header="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=UseBuffer}"
+                                    IsEnabled="{x:Bind InEditMode, Mode=OneWay}"
+                                    IsOn="{x:Bind ProfileVm.UseBuffer, Mode=TwoWay}" />
+
                                 <StackPanel Margin="{StaticResource ItemMargin}">
                                     <TextBlock
                                         x:Uid="EnvironmentVariables"
@@ -338,6 +345,18 @@
                                     <ContentControl
                                         Margin="0,6,0,0"
                                         Content="{x:Bind ProfileVm.UseConPty, Mode=OneWay}"
+                                        ContentTemplateSelector="{StaticResource UseConPtyTemplateSelector}"
+                                        FontSize="18"
+                                        FontWeight="Light" />
+                                </controls:HeaderedContentControl>
+
+                                <controls:HeaderedContentControl
+                                    Margin="{StaticResource ItemMargin}"
+                                    HorizontalContentAlignment="Stretch"
+                                    Header="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=UseBuffer}">
+                                    <ContentControl
+                                        Margin="0,6,0,0"
+                                        Content="{x:Bind ProfileVm.UseBuffer, Mode=OneWay}"
                                         ContentTemplateSelector="{StaticResource UseConPtyTemplateSelector}"
                                         FontSize="18"
                                         FontWeight="Light" />

--- a/FluentTerminal.App/Views/SettingsPages/SshProfileSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/SshProfileSettings.xaml
@@ -292,6 +292,7 @@
                                     IsOn="{x:Bind ProfileVm.UseConPty, Mode=TwoWay}" />
 
                                 <ToggleSwitch
+                                    Visibility="{x:Bind ProfileVm.UseConPty, Converter={StaticResource TrueToVisibleConverter}, Mode=OneWay}"
                                     Margin="{StaticResource ItemMargin}"
                                     Header="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=UseBuffer}"
                                     IsEnabled="{x:Bind InEditMode, Mode=OneWay}"

--- a/FluentTerminal.App/Views/SettingsPages/SshProfileSettings.xaml
+++ b/FluentTerminal.App/Views/SettingsPages/SshProfileSettings.xaml
@@ -291,6 +291,12 @@
                                     IsEnabled="{x:Bind InEditMode, Mode=OneWay}"
                                     IsOn="{x:Bind ProfileVm.UseConPty, Mode=TwoWay}" />
 
+                                <ToggleSwitch
+                                    Margin="{StaticResource ItemMargin}"
+                                    Header="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=UseBuffer}"
+                                    IsEnabled="{x:Bind InEditMode, Mode=OneWay}"
+                                    IsOn="{x:Bind ProfileVm.UseBuffer, Mode=TwoWay}" />
+
                                 <StackPanel Margin="{StaticResource ItemMargin}">
                                     <TextBlock
                                         x:Uid="EnvironmentVariables"
@@ -457,6 +463,19 @@
                                     <ContentControl
                                         Margin="0,6,0,0"
                                         Content="{Binding UseConPty, Mode=OneWay}"
+                                        ContentTemplateSelector="{StaticResource UseConPtyTemplateSelector}"
+                                        FontSize="18"
+                                        FontWeight="Light" />
+                                </controls:HeaderedContentControl>
+
+                                <controls:HeaderedContentControl
+                                    Margin="{StaticResource ItemMargin}"
+                                    HorizontalContentAlignment="Stretch"
+                                    DataContext="{Binding ProfileVm}"
+                                    Header="{x:Bind Converter={StaticResource I18NConverter}, ConverterParameter=UseBuffer}">
+                                    <ContentControl
+                                        Margin="0,6,0,0"
+                                        Content="{Binding UseBuffer, Mode=OneWay}"
                                         ContentTemplateSelector="{StaticResource UseConPtyTemplateSelector}"
                                         FontSize="18"
                                         FontWeight="Light" />

--- a/FluentTerminal.Models/ShellProfile.cs
+++ b/FluentTerminal.Models/ShellProfile.cs
@@ -30,6 +30,7 @@ namespace FluentTerminal.Models
             TabThemeId = other.TabThemeId;
             TerminalThemeId = other.TerminalThemeId;
             UseConPty = other.UseConPty;
+            UseBuffer = other.UseBuffer;
             KeyBindings = other.KeyBindings.Select(x => new KeyBinding(x)).ToList();
         }
 
@@ -42,6 +43,7 @@ namespace FluentTerminal.Models
         public int TabThemeId { get; set; }
         public Dictionary<string, string> EnvironmentVariables { get; set; } = new Dictionary<string, string>();
         public bool UseConPty { get; set; }
+        public bool UseBuffer { get; set; } = true;
 
         public int MigrationVersion { get; set; } = CurrentMigrationVersion;
 
@@ -75,6 +77,7 @@ namespace FluentTerminal.Models
                    && other.TabThemeId.Equals(TabThemeId)
                    && other.TerminalThemeId.Equals(TerminalThemeId)
                    && other.UseConPty == UseConPty
+                   && other.UseBuffer == UseBuffer
                    && other.KeyBindings.SequenceEqual(KeyBindings);
         }
 

--- a/FluentTerminal.SystemTray/Services/ConPty/ConPtySession.cs
+++ b/FluentTerminal.SystemTray/Services/ConPty/ConPtySession.cs
@@ -12,6 +12,7 @@ namespace FluentTerminal.SystemTray.Services.ConPty
         private Terminal _terminal;
 
         private BufferedReader _reader;
+        private bool _enableBuffer;
 
         public byte Id { get; private set; }
 
@@ -33,6 +34,11 @@ namespace FluentTerminal.SystemTray.Services.ConPty
 
         public void Start(CreateTerminalRequest request, TerminalsManager terminalsManager)
         {
+            _enableBuffer = request.Profile.UseBuffer;
+
+            _reader?.Dispose();
+            _reader = null;
+
             Id = request.Id;
             _terminalsManager = terminalsManager;
 
@@ -71,7 +77,7 @@ namespace FluentTerminal.SystemTray.Services.ConPty
             if (_reader == null)
             {
                 _reader = new BufferedReader(_terminal.ConsoleOutStream,
-                    bytes => _terminalsManager.DisplayTerminalOutput(Id, bytes));
+                    bytes => _terminalsManager.DisplayTerminalOutput(Id, bytes), _enableBuffer);
             }
         }
 

--- a/FluentTerminal.SystemTray/Services/WinPty/WinPtySession.cs
+++ b/FluentTerminal.SystemTray/Services/WinPty/WinPtySession.cs
@@ -18,9 +18,12 @@ namespace FluentTerminal.SystemTray.Services.WinPty
         private TerminalsManager _terminalsManager;
         private Process _shellProcess;
         private BufferedReader _reader;
+        private bool _enableBuffer;
 
         public void Start(CreateTerminalRequest request, TerminalsManager terminalsManager)
         {
+            _enableBuffer = request.Profile.UseBuffer;
+
             Id = request.Id;
             _terminalsManager = terminalsManager;
 
@@ -82,7 +85,8 @@ namespace FluentTerminal.SystemTray.Services.WinPty
                 winpty_error_free(errorHandle);
             }
 
-            _reader = new BufferedReader(_stdout, bytes => _terminalsManager.DisplayTerminalOutput(Id, bytes));
+            _reader = new BufferedReader(_stdout, bytes => _terminalsManager.DisplayTerminalOutput(Id, bytes),
+                _enableBuffer);
         }
 
         private void _shellProcess_Exited(object sender, EventArgs e)


### PR DESCRIPTION
This is alternative to https://github.com/felixse/FluentTerminal/pull/680. Here, "Use buffer" option is available only for ConPTY. Personally, I don't like this solution; I prefer https://github.com/felixse/FluentTerminal/pull/680, as I've explained there. But it's your call...