### PR TITLE
Rollback to use double quotes around identity file for ssh cli cmd.

### DIFF
--- a/FluentTerminal.App.ViewModels/Profiles/SshConnectViewModel.cs
+++ b/FluentTerminal.App.ViewModels/Profiles/SshConnectViewModel.cs
@@ -199,8 +199,8 @@ namespace FluentTerminal.App.ViewModels.Profiles
             }
 
             return _sshPort == SshProfile.DefaultSshPort
-                ? $"-i '{_identityFile}'"
-                : $"-p {_sshPort:#####} -i '{_identityFile}'";
+                ? $"-i \"{_identityFile}\""
+                : $"-p {_sshPort:#####} -i \"{_identityFile}\"";
         }
 
         protected override void LoadFromProfile(ShellProfile profile)


### PR DESCRIPTION
Fixes #685 

The change was introduced in https://github.com/felixse/FluentTerminal/commit/6868bfa7cac4196923985ac47e5cbc34b50e1f80#diff-0c0ed937950c1407065c4863a41838ddR200

Have tested locally both mosh and ssh.

Note: SSH profile should be re-saved to generate new cli arguments and update old incorrect args in user settings.