### PR TITLE
Fix for lack of focus on search textbox.

### DIFF
--- a/FluentTerminal.App/Actions/FocusAction.cs
+++ b/FluentTerminal.App/Actions/FocusAction.cs
@@ -9,9 +9,22 @@ namespace FluentTerminal.App.Actions
         public object Execute(object sender, object parameter)
         {
             var control = TargetObject ?? sender as Control;
-            control?.Focus(FocusState.Programmatic);
+            if (control != null)
+            {
+                if (!control.IsLoaded)
+                    control.Loaded += Control_Loaded;
+                else
+                    control.Focus(FocusState.Programmatic);
+            }
 
             return null;
+        }
+
+        private void Control_Loaded(object sender, RoutedEventArgs e)
+        {
+            Control control = sender as Control;
+            control.Focus(FocusState.Programmatic);
+            control.Loaded -= Control_Loaded; // won't be needed anymore. Remove reference just in case
         }
 
         public Control TargetObject


### PR DESCRIPTION
Focus was set before the control was visible most of the time. This fix will wait for the control to load if it is not visible. If it managed to load fast enough it will grab focus immediately instead.