### PR TITLE
Fix for a crash in search popup.

### DIFF
--- a/FluentTerminal.App.ViewModels/MainViewModel.cs
+++ b/FluentTerminal.App.ViewModels/MainViewModel.cs
@@ -71,6 +71,12 @@ namespace FluentTerminal.App.ViewModels
             _keyboardCommandService.RegisterCommandHandler(nameof(Command.DuplicateTab), async () => await AddTabAsync(SelectedTerminal.ShellProfile.Clone()));
             _keyboardCommandService.RegisterCommandHandler(nameof(Command.ReconnectTab), async () => { if (SelectedTerminal.ReconnectTabCommand.CanExecute()) await SelectedTerminal.ReconnectTabAsync(); });
 
+            // empty command handlers for copy and paste so that the main window does not execute these when copy keyboard shortcut is used in a popup search panel 
+            // in such a case an exception would be thrown if no handlers are available so these empty ones mitigate that. Also there is no need for these on the main window anyway
+            // so leaving them empty is fine.
+            _keyboardCommandService.RegisterCommandHandler(nameof(Command.Paste), () => { });
+            _keyboardCommandService.RegisterCommandHandler(nameof(Command.Copy), () => { });
+
             // Add all of the commands for switching to a tab of a given ID, if there's one open there
             for (int i = 0; i < 9; i++)
             {

--- a/FluentTerminal.App.ViewModels/TerminalViewModel.cs
+++ b/FluentTerminal.App.ViewModels/TerminalViewModel.cs
@@ -386,6 +386,8 @@ namespace FluentTerminal.App.ViewModels
             set => Set(ref _showSearchPanel, value);
         }
 
+        public bool SearchHasFocus { get; set; }
+
         public TabThemeViewModel TabTheme
         {
             get => _tabTheme;
@@ -761,10 +763,15 @@ namespace FluentTerminal.App.ViewModels
 
         private async Task Paste()
         {
-            var content = await ClipboardService.GetTextAsync().ConfigureAwait(false);
-            if (content != null)
+            // prevent from pasting something into the terminal window when the actual command is executed
+            // while being in the search box
+            if (!SearchHasFocus)
             {
-                TerminalView.Paste(content);
+                var content = await ClipboardService.GetTextAsync().ConfigureAwait(false);
+                if (content != null)
+                {
+                    TerminalView.Paste(content);
+                }
             }
         }
 

--- a/FluentTerminal.App/Views/TerminalView.xaml
+++ b/FluentTerminal.App/Views/TerminalView.xaml
@@ -47,7 +47,9 @@
                     IsTabStop="True"
                     KeyUp="OnSearchTextBoxKeyUp"
                     PlaceholderText="Enter search term"
-                    Text="{x:Bind ViewModel.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                    Text="{x:Bind ViewModel.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    GotFocus="SearchTextBox_GotFocus"
+                    LostFocus="SearchTextBox_LostFocus">
                     <Interactivity:Interaction.Behaviors>
                         <Core:DataTriggerBehavior Binding="{x:Bind ViewModel.ShowSearchPanel, Mode=OneWay}" Value="true">
                             <actions:FocusAction />

--- a/FluentTerminal.App/Views/TerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/TerminalView.xaml.cs
@@ -138,5 +138,15 @@ namespace FluentTerminal.App.Views
 
             TerminalContainer.Background = backgroundBrush;
         }
+
+        private void SearchTextBox_GotFocus(object sender, RoutedEventArgs e)
+        {
+            ViewModel.SearchHasFocus = true;
+        }
+
+        private void SearchTextBox_LostFocus(object sender, RoutedEventArgs e)
+        {
+            ViewModel.SearchHasFocus = false;
+        }
     }
 }


### PR DESCRIPTION
The crash occured because the popup is treated like the mainwindow and the main window grabs keypresses. Because of this a paste command can be executed on the main window when attempting to paste into the search box (when ctrl-c is used as a paste binding).
Adding an empty binding for copy and paste resolves this. Additionally it was required to prevent the terminal view from handling paste requests to prevent pasting to searchbox and terminal at the same time.