### PR TITLE
Improved the way the search flyout is behaving.

### DIFF
--- a/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
+++ b/FluentTerminal.App.Services/Implementation/DefaultValueProvider.cs
@@ -283,6 +283,16 @@ namespace FluentTerminal.App.Services.Implementation
                     }
                 };
 
+                case Command.CloseSearch:
+                    return new List<KeyBinding>
+                {
+                    new KeyBinding
+                    {
+                        Command = nameof(Command.CloseSearch),
+                        Key = (int)ExtendedVirtualKey.Escape
+                    }
+                };
+
                 case Command.ToggleFullScreen:
                     return new List<KeyBinding>
                 {

--- a/FluentTerminal.App.ViewModels/TerminalViewModel.cs
+++ b/FluentTerminal.App.ViewModels/TerminalViewModel.cs
@@ -18,6 +18,7 @@ using FluentTerminal.App.ViewModels.Menu;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace FluentTerminal.App.ViewModels
 {
@@ -281,12 +282,14 @@ namespace FluentTerminal.App.ViewModels
                 {
                     if (IsSelected)
                     {
-                        _keyboardCommandService.RegisterCommandHandler(nameof(Command.Search), () => ShowSearchPanel = !ShowSearchPanel);
+                        _keyboardCommandService.RegisterCommandHandler(nameof(Command.Search), () => ShowSearchPanel = true);
+                        _keyboardCommandService.RegisterCommandHandler(nameof(Command.CloseSearch), () => CloseSearchPanel());
                         HasNewOutput = false;
                     }
                     else
                     {
                         _keyboardCommandService.DeregisterCommandHandler(nameof(Command.Search));
+                        _keyboardCommandService.DeregisterCommandHandler(nameof(Command.CloseSearch));
                     }
                     RaisePropertyChanged(nameof(IsUnderlined));
                     RaisePropertyChanged(nameof(BackgroundTabTheme));
@@ -676,11 +679,16 @@ namespace FluentTerminal.App.ViewModels
                     {
                         await ApplicationView.ExecuteOnUiThreadAsync(() =>
                         {
-                            ShowSearchPanel = !ShowSearchPanel;
-                            if (ShowSearchPanel)
-                            {
-                                SearchStarted?.Invoke(this, EventArgs.Empty);
-                            }
+                            ShowSearchPanel = true;
+                            SearchStarted?.Invoke(this, EventArgs.Empty);
+                        }).ConfigureAwait(false);
+                        return;
+                    }
+                case nameof(Command.CloseSearch):
+                    {
+                        await ApplicationView.ExecuteOnUiThreadAsync(() =>
+                        {
+                            CloseSearchPanel();
                         }).ConfigureAwait(false);
                         return;
                     }

--- a/FluentTerminal.App/Strings/ar-iq/Resources.resw
+++ b/FluentTerminal.App/Strings/ar-iq/Resources.resw
@@ -673,6 +673,10 @@
     <value>بحث</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>اختر الكل</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/ar/Resources.resw
+++ b/FluentTerminal.App/Strings/ar/Resources.resw
@@ -689,6 +689,10 @@ Fuzzy</comment>
     <value>بحث</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>تحديد الكل</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/az-Latn/Resources.resw
+++ b/FluentTerminal.App/Strings/az-Latn/Resources.resw
@@ -673,6 +673,10 @@
     <value>Axtarış</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>Hamısını seç</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/de/Resources.resw
+++ b/FluentTerminal.App/Strings/de/Resources.resw
@@ -687,6 +687,10 @@ Fuzzy</comment>
     <value>Suchen</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>Alles auswählen</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/en-US/Resources.resw
+++ b/FluentTerminal.App/Strings/en-US/Resources.resw
@@ -704,6 +704,10 @@ Fuzzy</comment>
     <comment>Command
 Fuzzy</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>Select all</value>
     <comment>Command

--- a/FluentTerminal.App/Strings/eo/Resources.resw
+++ b/FluentTerminal.App/Strings/eo/Resources.resw
@@ -673,7 +673,11 @@
     <value>Serĉi</value>
     <comment>Command</comment>
   </data>
-  <data name="Command.SelectAll" xml:space="preserve">
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
+	<data name="Command.SelectAll" xml:space="preserve">
     <value>Elekti ĉiujn</value>
     <comment>Command</comment>
   </data>

--- a/FluentTerminal.App/Strings/es/Resources.resw
+++ b/FluentTerminal.App/Strings/es/Resources.resw
@@ -683,7 +683,11 @@ Fuzzy</comment>
     <value>Buscar</value>
     <comment>Command</comment>
   </data>
-  <data name="Command.SelectAll" xml:space="preserve">
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
+	<data name="Command.SelectAll" xml:space="preserve">
     <value>Seleccionar todo</value>
     <comment>Command</comment>
   </data>

--- a/FluentTerminal.App/Strings/fa/Resources.resw
+++ b/FluentTerminal.App/Strings/fa/Resources.resw
@@ -673,7 +673,11 @@
     <value>جستجو</value>
     <comment>Command</comment>
   </data>
-  <data name="Command.SelectAll" xml:space="preserve">
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
+	<data name="Command.SelectAll" xml:space="preserve">
     <value>انتخاب همه</value>
     <comment>Command</comment>
   </data>

--- a/FluentTerminal.App/Strings/fr/Resources.resw
+++ b/FluentTerminal.App/Strings/fr/Resources.resw
@@ -703,6 +703,10 @@ Fuzzy</comment>
     <comment>Command
 Fuzzy</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>Sélectionner tout</value>
     <comment>Command

--- a/FluentTerminal.App/Strings/he/Resources.resw
+++ b/FluentTerminal.App/Strings/he/Resources.resw
@@ -680,6 +680,10 @@ Fuzzy</comment>
     <value>חיפוש</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>סמן הכל</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/hi/Resources.resw
+++ b/FluentTerminal.App/Strings/hi/Resources.resw
@@ -673,6 +673,10 @@
     <value>खोज</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>सभी का चयन करे</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/hr/Resources.resw
+++ b/FluentTerminal.App/Strings/hr/Resources.resw
@@ -673,6 +673,10 @@
     <value>Traži</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>Odaberi sve</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/hu/Resources.resw
+++ b/FluentTerminal.App/Strings/hu/Resources.resw
@@ -691,6 +691,10 @@ Fuzzy</comment>
     <value>Keresés</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>Összes kijelölése</value>
     <comment>Command

--- a/FluentTerminal.App/Strings/id/Resources.resw
+++ b/FluentTerminal.App/Strings/id/Resources.resw
@@ -673,6 +673,10 @@
     <value>Cari</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>Pilih semua</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/it/Resources.resw
+++ b/FluentTerminal.App/Strings/it/Resources.resw
@@ -675,6 +675,10 @@ Fuzzy</comment>
     <value>Cerca</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>Seleziona tutto</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/ja/Resources.resw
+++ b/FluentTerminal.App/Strings/ja/Resources.resw
@@ -673,6 +673,10 @@
     <value>検索</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>すべて選択</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/ko/Resources.resw
+++ b/FluentTerminal.App/Strings/ko/Resources.resw
@@ -677,6 +677,10 @@ Fuzzy</comment>
     <value>찾기</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>모두 선택</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/nl/Resources.resw
+++ b/FluentTerminal.App/Strings/nl/Resources.resw
@@ -704,6 +704,10 @@ Fuzzy</comment>
     <comment>Command
 Fuzzy</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>Selecteer alles</value>
     <comment>Command

--- a/FluentTerminal.App/Strings/pl/Resources.resw
+++ b/FluentTerminal.App/Strings/pl/Resources.resw
@@ -673,6 +673,10 @@
     <value>Szukaj</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>Zaznacz wszysto</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/pt-BR/Resources.resw
+++ b/FluentTerminal.App/Strings/pt-BR/Resources.resw
@@ -673,6 +673,10 @@
     <value>Buscar</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>Selecionar tudo</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/ro/Resources.resw
+++ b/FluentTerminal.App/Strings/ro/Resources.resw
@@ -673,6 +673,10 @@
     <value>Căutare</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>Selectează tot</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/ru/Resources.resw
+++ b/FluentTerminal.App/Strings/ru/Resources.resw
@@ -673,6 +673,10 @@
     <value>Поиск</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>Выделить всё</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/sl/Resources.resw
+++ b/FluentTerminal.App/Strings/sl/Resources.resw
@@ -673,6 +673,10 @@
     <value>Išči</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>Izberi vse</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/tr/Resources.resw
+++ b/FluentTerminal.App/Strings/tr/Resources.resw
@@ -674,6 +674,10 @@
     <value>Arama</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>Tümünü Seç</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/ug-Arab/Resources.resw
+++ b/FluentTerminal.App/Strings/ug-Arab/Resources.resw
@@ -674,6 +674,10 @@
     <value>ئىزدەش</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>ھەممىنى تاللاش</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/uk/Resources.resw
+++ b/FluentTerminal.App/Strings/uk/Resources.resw
@@ -673,7 +673,15 @@
     <value>Пошук</value>
     <comment>Command</comment>
   </data>
-  <data name="Command.SelectAll" xml:space="preserve">
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
+	<data name="Command.SelectAll" xml:space="preserve">
     <value>Виділити все</value>
     <comment>Command</comment>
   </data>

--- a/FluentTerminal.App/Strings/zh-Hans/Resources.resw
+++ b/FluentTerminal.App/Strings/zh-Hans/Resources.resw
@@ -693,6 +693,10 @@ Fuzzy</comment>
     <value>搜索</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>全选</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Strings/zh-Hant/Resources.resw
+++ b/FluentTerminal.App/Strings/zh-Hant/Resources.resw
@@ -673,6 +673,10 @@
     <value>搜尋</value>
     <comment>Command</comment>
   </data>
+  <data name="Command.CloseSearch" xml:space="preserve">
+    <value>Close search</value>
+    <comment>Command</comment>
+  </data>
   <data name="Command.SelectAll" xml:space="preserve">
     <value>全選</value>
     <comment>Command</comment>

--- a/FluentTerminal.App/Views/TerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/TerminalView.xaml.cs
@@ -94,11 +94,7 @@ namespace FluentTerminal.App.Views
 
         private void OnSearchTextBoxKeyUp(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)
         {
-            if (e.Key == VirtualKey.Escape)
-            {
-                ViewModel.CloseSearchPanelCommand.Execute(null);
-            }
-            else if (e.Key == VirtualKey.Enter)
+            if (e.Key == VirtualKey.Enter)
             {
                 ViewModel.FindPreviousCommand.Execute(null);
             }
@@ -141,12 +137,14 @@ namespace FluentTerminal.App.Views
 
         private void SearchTextBox_GotFocus(object sender, RoutedEventArgs e)
         {
-            ViewModel.SearchHasFocus = true;
+            if (ViewModel != null)
+                ViewModel.SearchHasFocus = true;
         }
 
         private void SearchTextBox_LostFocus(object sender, RoutedEventArgs e)
         {
-            ViewModel.SearchHasFocus = false;
+            if (ViewModel != null)
+                ViewModel.SearchHasFocus = false;
         }
     }
 }

--- a/FluentTerminal.Models/Enums/Command.cs
+++ b/FluentTerminal.Models/Enums/Command.cs
@@ -18,6 +18,7 @@
         Paste,
         PasteWithoutNewlines,
         Search,
+        CloseSearch,
         ToggleFullScreen,
         SelectAll,
         Clear,


### PR DESCRIPTION
The search command will now show the flyout and focus on the textbox. If the textbox has no focus and search command is used again it will focus the textbox.
A new command has been added to close the search flyout (escape by default) which can now be used to close it if the app has focus. 
Previous behavior is somewhat odd compared to how nearly all other apps are handling it. 