### PR TITLE
Adjusted the behavior of search so that the previous text is selected when search is active

### DIFF
--- a/FluentTerminal.App/Views/TerminalView.xaml.cs
+++ b/FluentTerminal.App/Views/TerminalView.xaml.cs
@@ -90,6 +90,7 @@ namespace FluentTerminal.App.Views
         private void OnSearchStarted(object sender, EventArgs e)
         {
             SearchTextBox.Focus(FocusState.Programmatic);
+            SearchTextBox.SelectAll();
         }
 
         private void OnSearchTextBoxKeyUp(object sender, Windows.UI.Xaml.Input.KeyRoutedEventArgs e)


### PR DESCRIPTION
When the search flyout is visible but not focused the text is now selected when search focus is requested.
This behavior mimics other tools.