### PR TITLE
added quotes in the icon copy line (first line)

### DIFF
--- a/Explorer Context Menu Integration/Install_with_icon.bat
+++ b/Explorer Context Menu Integration/Install_with_icon.bat
@@ -1,4 +1,4 @@
-copy /y FluentTerminal.ico %LOCALAPPDATA%\Microsoft\WindowsApps
+copy /y FluentTerminal.ico "%LOCALAPPDATA%\Microsoft\WindowsApps"
 reg add "HKCU\Software\Classes\Directory\shell\Open Fluent Terminal here\command" /d "\"%LOCALAPPDATA%\Microsoft\WindowsApps\flute.exe\" new \"%%V\"" /f
 reg add "HKCU\Software\Classes\Directory\shell\Open Fluent Terminal here" /v icon /t REG_SZ /d "%LOCALAPPDATA%\Microsoft\WindowsApps\FluentTerminal.ico" /f
 reg add "HKCU\Software\Classes\Directory\Background\shell\Open Fluent Terminal here\command" /d "\"%LOCALAPPDATA%\Microsoft\WindowsApps\flute.exe\" new \"%%V\"" /f


### PR DESCRIPTION
The icon does not copy when you have a path with blanks. Added quotes to copy in any case